### PR TITLE
[statsig-rust] Write errors to stderr not stdout

### DIFF
--- a/statsig-rust/Cargo.toml
+++ b/statsig-rust/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = "1.0.125", features = [
 serde_with = "3.4.0"
 sha2 = "0.10.8"
 sigstat-grpc = { path = "../statsig-grpc", version = "0.4.0", optional = true }
-simple_logger = "5.0.0"
+simple_logger = { version = "5.0.0", features = ["stderr"] }
 tokio = { version = "1.39.1", features = ["full"] }
 uaparser = "0.6.4"
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }


### PR DESCRIPTION
Libraries shouldn't be writing errors to stdout, but to stderr. simple_logger supports this, but for some reason it's not the default: https://docs.rs/simple_logger/latest/src/simple_logger/lib.rs.html#477

This switches to stderr.