### PR TITLE
[Elixir] Move modules to Statsig namespace

### DIFF
--- a/statsig-elixir/lib/statsig.ex
+++ b/statsig-elixir/lib/statsig.ex
@@ -1,6 +1,8 @@
 defmodule Statsig do
   use GenServer
 
+  alias Statsig.NativeBindings
+
   def start_link(sdk_key, options) do
     GenServer.start_link(__MODULE__, {sdk_key, options}, name: __MODULE__)
   end
@@ -114,7 +116,7 @@ defmodule Statsig do
     end
   end
 
-  @spec log_event(%StatsigUser{}, String.t(), String.t() | number(), %{String.t() => String.t()}) ::
+  @spec log_event(%Statsig.User{}, String.t(), String.t() | number(), %{String.t() => String.t()}) ::
           any()
   def log_event(statsig_user, event_name, value, metadata) do
     try do

--- a/statsig-elixir/lib/statsig/dynamic_config.ex
+++ b/statsig-elixir/lib/statsig/dynamic_config.ex
@@ -1,4 +1,4 @@
-defmodule DynamicConfig do
+defmodule Statsig.DynamicConfig do
   defstruct [
     :name,
     :value,

--- a/statsig-elixir/lib/statsig/experiment.ex
+++ b/statsig-elixir/lib/statsig/experiment.ex
@@ -1,4 +1,4 @@
-defmodule Experiment do
+defmodule Statsig.Experiment do
   @moduledoc """
   Get experiment and it's corresponding serialized values
   """

--- a/statsig-elixir/lib/statsig/feature_gate.ex
+++ b/statsig-elixir/lib/statsig/feature_gate.ex
@@ -1,4 +1,4 @@
-defmodule FeatureGate do
+defmodule Statsig.FeatureGate do
   defstruct [
     :name,
     :value,

--- a/statsig-elixir/lib/statsig/layer.ex
+++ b/statsig-elixir/lib/statsig/layer.ex
@@ -1,8 +1,11 @@
-defmodule Layer do
+defmodule Statsig.Layer do
   @moduledoc """
   Functions to get values, metadata e.g. group_name for layer
   Layer object is not a struct, instead it's a reference to a layer struct defined in statsig-core (Binary library)
   """
+
+  alias Statsig.NativeBindings
+
   def get_name(layer) do
     try do
       {:ok, NativeBindings.layer_get_name(layer)}

--- a/statsig-elixir/lib/statsig/native_bindings.ex
+++ b/statsig-elixir/lib/statsig/native_bindings.ex
@@ -1,4 +1,4 @@
-defmodule NativeBindings do
+defmodule Statsig.NativeBindings do
   version = Mix.Project.config()[:version] |> to_string()
   use RustlerPrecompiled,
     otp_app: :statsig_elixir,

--- a/statsig-elixir/lib/statsig/options.ex
+++ b/statsig-elixir/lib/statsig/options.ex
@@ -1,5 +1,5 @@
 
-defmodule StatsigOptions do
+defmodule Statsig.Options do
   defstruct [
     environment: nil,
     output_log_level: nil,

--- a/statsig-elixir/lib/statsig/user.ex
+++ b/statsig-elixir/lib/statsig/user.ex
@@ -1,4 +1,4 @@
-defmodule StatsigUser do
+defmodule Statsig.User do
   defstruct [
     user_id: "",
     email: nil,

--- a/statsig-elixir/native/statsig_elixir/src/statsig_nfi.rs
+++ b/statsig-elixir/native/statsig_elixir/src/statsig_nfi.rs
@@ -257,4 +257,4 @@ pub fn layer_get_group_name(layer: ResourceArc<LayerResource>) -> Result<Option<
     }
 }
 
-rustler::init!("Elixir.NativeBindings", load = load);
+rustler::init!("Elixir.Statsig.NativeBindings", load = load);

--- a/statsig-elixir/native/statsig_elixir/src/statsig_options_nfi.rs
+++ b/statsig-elixir/native/statsig_elixir/src/statsig_options_nfi.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use statsig_rust::statsig_options::StatsigOptions as StatsigOptionsActual;
 
 #[derive(NifStruct, Serialize)]
-#[module = "StatsigOptions"]
+#[module = "Statsig.Options"]
 pub struct StatsigOptions {
     pub environment: Option<String>,
     pub output_log_level: Option<String>,

--- a/statsig-elixir/native/statsig_elixir/src/statsig_types_nfi.rs
+++ b/statsig-elixir/native/statsig_elixir/src/statsig_types_nfi.rs
@@ -6,7 +6,7 @@ use statsig_rust::statsig_types::{
 };
 use statsig_rust::DynamicValue;
 #[derive(NifStruct)]
-#[module = "Experiment"]
+#[module = "Statsig.Experiment"]
 pub struct Experiment {
     pub name: String,
     pub rule_id: String,
@@ -28,7 +28,7 @@ impl From<ExperimentActual> for Experiment {
 }
 
 #[derive(NifStruct)]
-#[module = "DynamicConfig"]
+#[module = "Statsig.DynamicConfig"]
 pub struct DynamicConfig {
     pub name: String,
     pub value: String,
@@ -48,7 +48,7 @@ impl From<DynamicConfigActual> for DynamicConfig {
 }
 
 #[derive(NifStruct)]
-#[module = "FeatureGate"]
+#[module = "Statsig.FeatureGate"]
 pub struct FeatureGate {
     pub name: String,
     pub value: bool,

--- a/statsig-elixir/native/statsig_elixir/src/statsig_user_nfi.rs
+++ b/statsig-elixir/native/statsig_elixir/src/statsig_user_nfi.rs
@@ -12,7 +12,7 @@ macro_rules! to_value_with_dynamic {
 }
 
 #[derive(NifStruct)]
-#[module = "StatsigUser"]
+#[module = "Statsig.User"]
 pub struct StatsigUser {
     pub user_id: String,
     pub email: Option<String>,

--- a/statsig-elixir/test/statsig_test.exs
+++ b/statsig-elixir/test/statsig_test.exs
@@ -2,6 +2,12 @@ defmodule StatsigTest do
   use ExUnit.Case
   doctest Statsig
 
+  alias Statsig.DynamicConfig
+  alias Statsig.Experiment
+  alias Statsig.Layer
+  alias Statsig.Options
+  alias Statsig.User
+
   test "Example usage test" do
     # Initialize Statsig with a test SDK key
     IO.puts("\n=== Starting Statsig Test ===")
@@ -12,12 +18,12 @@ defmodule StatsigTest do
       :ok
     end
 
-    statsig_options = %StatsigOptions{enable_id_lists: true}
+    statsig_options = %Options{enable_id_lists: true}
     IO.puts("Initializing with SDK key: #{sdk_key}")
     Statsig.start_link(sdk_key, statsig_options)
 
     # Create a test user
-    user = %StatsigUser{
+    user = %User{
       user_id: "test_user_123",
       email: "test@email.com",
       custom_ids: %{


### PR DESCRIPTION
Hi Statsig team,

The Elixir convention is that packages should namespace all their modules below a unique name so that module names don't conflict within an application.  In this PR I'm just renaming the top-level modules to be under the `Statsig` namespace.

Let me know if you have any questions or concerns, thanks!