### PR TITLE
Fix arch-dependent bucketing

### DIFF
--- a/statsig-rust/src/evaluation/cmab_evaluator.rs
+++ b/statsig-rust/src/evaluation/cmab_evaluator.rs
@@ -210,7 +210,7 @@ fn is_cmab_started(cmab: &CMABConfig) -> bool {
 fn apply_random_group<'a>(
     ctx: &mut EvaluatorContext<'a>,
     cmab: &'a CMABConfig,
-    user_hash: Option<usize>,
+    user_hash: Option<u64>,
 ) {
     let group_size = 10000.0 / (cmab.groups.len() as f64);
     let group = match user_hash {

--- a/statsig-rust/src/hashing/hash_util.rs
+++ b/statsig-rust/src/hashing/hash_util.rs
@@ -71,7 +71,7 @@ impl HashUtil {
         u64::from_be_bytes(hasher_bytes)
     }
 
-    pub fn evaluation_hash(&self, input: &String) -> Option<usize> {
+    pub fn evaluation_hash(&self, input: &String) -> Option<u64> {
         self.sha_hasher.compute_hash(input)
     }
 }

--- a/statsig-rust/tests/hash_util_evaluation_hash_tests.rs
+++ b/statsig-rust/tests/hash_util_evaluation_hash_tests.rs
@@ -5,12 +5,16 @@ fn test_evaluation_hash_matches_sha256_prefix() {
     let hasher = HashUtil::new();
 
     // expect first 8 bytes of SHA-256 digest as big-endian u64:
-    let got = hasher.evaluation_hash(&"".to_string()).expect("hash");
-    assert_eq!(got, 0xE3B0C44298FC1C14);
-
-    let got = hasher.evaluation_hash(&"blargh".to_string()).expect("hash");
-    assert_eq!(got, 0x0AC33512D18E20D5);
-
-    let got = hasher.evaluation_hash(&"🗻".to_string()).expect("hash");
-    assert_eq!(got, 0x1DDBF4EA8DAE91E5);
+    assert_eq!(
+        hasher.evaluation_hash(&"".to_string()).unwrap() as u64,
+        0xE3B0C44298FC1C14_u64
+    );
+    assert_eq!(
+        hasher.evaluation_hash(&"blargh".to_string()).unwrap() as u64,
+        0x0AC33512D18E20D5_u64
+    );
+    assert_eq!(
+        hasher.evaluation_hash(&"unicode 🗻".to_string()).unwrap() as u64,
+        0xD460740C12959D83_u64
+    );
 }

--- a/statsig-rust/tests/hash_util_evaluation_hash_tests.rs
+++ b/statsig-rust/tests/hash_util_evaluation_hash_tests.rs
@@ -1,0 +1,16 @@
+use statsig_rust::hashing::HashUtil;
+
+#[test]
+fn test_evaluation_hash_matches_sha256_prefix() {
+    let hasher = HashUtil::new();
+
+    // expect first 8 bytes of SHA-256 digest as big-endian u64:
+    let got = hasher.evaluation_hash(&"".to_string()).expect("hash");
+    assert_eq!(got, 0xE3B0C44298FC1C14);
+
+    let got = hasher.evaluation_hash(&"blargh".to_string()).expect("hash");
+    assert_eq!(got, 0x0AC33512D18E20D5);
+
+    let got = hasher.evaluation_hash(&"🗻".to_string()).expect("hash");
+    assert_eq!(got, 0x1DDBF4EA8DAE91E5);
+}


### PR DESCRIPTION
Currently in the Rust library, user assignment can differ in 32‑ vs. 64‑bit builds because the hash being used for bucketing gets truncated to different lengths. This PR standardizes bucketing by grabbing the first 64 bits of the hash regardless of target architecture, matching the behavior of other Statsig libraries.

Tested 32-bit behavior by using `cross`:

```sh
cross test --target i686-unknown-linux-gnu --test hash_util_evaluation_hash_tests
```