### PR TITLE
[statsig-rust] Restore Wasm cfg gates in Cargo.toml

### DIFF
--- a/statsig-rust/Cargo.toml
+++ b/statsig-rust/Cargo.toml
@@ -14,7 +14,6 @@ async-trait = "0.1.81"
 base64 = "0.22.1"
 chrono = "0.4.40"
 dashmap = "6.1.0"
-file-guard = "0.2.0"
 flate2 = "1.0.35"
 futures = "0.3.30"
 lazy-regex = "3.4.1"
@@ -40,10 +39,18 @@ serde_with = "3.4.0"
 sha2 = "0.10.8"
 sigstat-grpc = { path = "../statsig-grpc", version = "0.9.1", optional = true }
 simple_logger = { version = "5.0.0" }
-tokio = { version = "1.39.1", features = ["full"] }
 uaparser = "0.6.4"
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 zstd = { version = "0.13.2", features = ["zdict_builder"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { version = "1.39.1", features = ["full"] }
+file-guard = { version = "0.2.0" }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+tokio = { version = "1.39.1", default-features = false, features = ["rt", "macros", "time", "sync"] }
+# ^ "rt-multi-thread" unavailable in wasm
+
 [target.'cfg(target_env = "gnu")'.dependencies]
 libc = "0.2"
 


### PR DESCRIPTION
Followup to https://github.com/statsig-io/statsig-server-core/pull/17. It looks like the update to Cargo.toml was missed in the release, possibly in resolving a merge conflict (appreciate the work you do!)