### PR TITLE
chore(deps): remove xUnit dependency and update test SDK

### DIFF
--- a/statsig-dotnet/src/Statsig/Statsig.csproj
+++ b/statsig-dotnet/src/Statsig/Statsig.csproj
@@ -24,9 +24,7 @@
     <PackageReference Include="Statsig.NativeAssets.win-x86"    Version="$(StatsigVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalProjects)' == 'true'">
     <ProjectReference Include="../Native/Statsig.NativeAssets.osx-arm64.csproj" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />

--- a/statsig-dotnet/test/Statsig.Tests.csproj
+++ b/statsig-dotnet/test/Statsig.Tests.csproj
@@ -7,9 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Moq" Version="4.16.1" />


### PR DESCRIPTION
This pull request updates the test dependencies in the project to use newer versions and improves the configuration for test asset management. The main changes focus on upgrading `xunit` and related packages, as well as cleaning up unused test dependencies in the main project file.

**Test dependency upgrades:**

* Upgraded `Microsoft.NET.Test.Sdk` from version `17.11.1` to `18.0.0` in `Statsig.Tests.csproj`, ensuring compatibility with the latest test runner features.
* Upgraded `xunit` from version `2.9.2` to `2.9.3` and `xunit.runner.visualstudio` from `2.4.3` to `3.1.5` in `Statsig.Tests.csproj`, and added asset management settings for better isolation and control over test dependencies.

**Project file cleanup:**

* Removed `Microsoft.NET.Test.Sdk` and `xunit` test dependencies from the main `Statsig.csproj` file to ensure they are only referenced in the test project.