### PR TITLE
[statsig-node] Fix EPIPE errors with proper HTTP agent connection pooling and timeouts

### DIFF
--- a/statsig-node/package.json
+++ b/statsig-node/package.json
@@ -12,7 +12,8 @@
   "repository": "https://github.com/statsig-io/statsig-server-core.git",
   "dependencies": {
     "@octokit/core": "^6",
-    "https-proxy-agent": "^7.0.6",
+    "agentkeepalive": "^4.5.0",
+    "hpagent": "^1.2.0",
     "node-fetch": "2.7.0"
   },
   "devDependencies": {

--- a/statsig-node/pnpm-lock.yaml
+++ b/statsig-node/pnpm-lock.yaml
@@ -11,9 +11,12 @@ importers:
       '@octokit/core':
         specifier: ^6
         version: 6.1.6
-      https-proxy-agent:
-        specifier: ^7.0.6
-        version: 7.0.6
+      agentkeepalive:
+        specifier: ^4.5.0
+        version: 4.6.0
+      hpagent:
+        specifier: ^1.2.0
+        version: 1.2.0
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0
@@ -989,9 +992,9 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -1450,6 +1453,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1457,13 +1464,12 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3276,7 +3282,9 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  agent-base@7.1.4: {}
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -3778,6 +3786,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hpagent@1.2.0: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.0:
@@ -3788,14 +3798,11 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   human-signals@2.1.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   iconv-lite@0.4.24:
     dependencies:


### PR DESCRIPTION
# Fix EPIPE Errors with Proper HTTP Agent Connection Pooling and Timeouts

## Problem

The Node.js SDK was experiencing EPIPE (broken pipe / socket connection issues) errors for us when making HTTP requests. These errors occurred due to:

1. **Improper connection pooling**: The previous implementation using `https-proxy-agent` didn't properly handle connection reuse
2. **Missing timeout configuration**: No `freeSocketTimeout` was configured, causing stale connections to be reused after the server had closed them
3. **Inadequate keep-alive settings**: Connection pooling wasn't configured with proper timeout values

## Solution

This PR replaces `https-proxy-agent` with `agentkeepalive` and `hpagent` to implement proper HTTP agent connection pooling with comprehensive timeout configuration:

### Key Changes

1. **Replaced dependencies**:
   - Removed: `https-proxy-agent@^7.0.6`
   - Added: `agentkeepalive@^4.5.0` and `hpagent@^1.2.0`

2. **Implemented shared HTTP/HTTPS agents** with proper timeout configuration:
   - `timeout: 30000` - Request timeout matching SDK defaults
   - `freeSocketTimeout: 15000` - Prevents EPIPE errors from stale connections
   - `keepAlive: true` and `keepAliveMsecs: 1000` - Enables connection reuse

3. **Enhanced proxy support**:
   - Updated `createProxyAgent` → `createProxyAgents` to return both HTTP and HTTPS agents
   - Both proxy agents use the same timeout configuration as direct connections
   - Added `getAgent` helper function to select the appropriate agent based on URL protocol

### Technical Details

- **`agentkeepalive`**: Provides `freeSocketTimeout` support across all Node.js versions, which is critical for preventing EPIPE errors when connections are reused after being idle
- **`hpagent`**: Supports all standard agent options (including `keepAlive` and `freeSocketTimeout`) for proxy scenarios, ensuring consistent behavior whether using a proxy or direct connections

### Benefits

- ✅ Prevents EPIPE errors by properly handling stale connections
- ✅ Improves connection reliability through proper connection pooling
- ✅ Maintains backward compatibility - no breaking changes to the API
- ✅ Works consistently with or without proxy configuration

## Testing

- All existing tests pass (120 tests)
- No breaking changes to the public API
- Backward compatible with existing proxy configurations
- Tested it separately in our own infrastructure: [this package](https://www.npmjs.com/package/@holbrookab_augment/statsig-node-core) contains the changed code).  We don't use the proxy but the other changes have not resulted in any prior socket issues in 2 days of current test.

## Files Changed

- `statsig-node/package.json` - Updated dependencies
- `statsig-node/src/lib/index.ts` - Core HTTP agent implementation
- `statsig-node/pnpm-lock.yaml` - Lock file updates

