### PR TITLE
fix: layer conditional overrides fail to resolve experiments

### DIFF
--- a/statsig-rust/src/evaluation/evaluator.rs
+++ b/statsig-rust/src/evaluation/evaluator.rs
@@ -331,7 +331,11 @@ fn try_apply_config_mapping(
             let pass = evaluate_pass_percentage(ctx, rule, spec_salt);
             if pass {
                 ctx.result.override_config_name = Some(mapping.new_config_name.clone());
-                match Evaluator::evaluate(ctx, mapping.new_config_name.as_str(), spec_type) {
+                let resolved_type = match spec_type {
+                    SpecType::Layer => &SpecType::Experiment,
+                    other => other,
+                };
+                match Evaluator::evaluate(ctx, mapping.new_config_name.as_str(), resolved_type) {
                     Ok(Recognition::Recognized) => {
                         return true;
                     }

--- a/statsig-rust/tests/data/layer_conditional_override_dcs.json
+++ b/statsig-rust/tests/data/layer_conditional_override_dcs.json
@@ -1,0 +1,227 @@
+{
+  "company_id": "test-company",
+  "has_updates": true,
+  "time": 1700000000000,
+  "response_format": "dcs-v2",
+  "feature_gates": {
+    "segment:test_id_list_segment": {
+      "type": "feature_gate",
+      "salt": "segment-salt",
+      "enabled": true,
+      "defaultValue": false,
+      "rules": [
+        {
+          "name": "id_list_rule",
+          "passPercentage": 100,
+          "conditions": [
+            "cond_in_segment_list"
+          ],
+          "returnValue": true,
+          "id": "id_list_rule",
+          "salt": "",
+          "idType": "userID"
+        }
+      ],
+      "idType": "userID",
+      "entity": "segment",
+      "version": 1
+    },
+    "always_pass_gate": {
+      "type": "feature_gate",
+      "salt": "gate-salt-1",
+      "enabled": true,
+      "defaultValue": false,
+      "rules": [
+        {
+          "name": "public_rule",
+          "passPercentage": 100,
+          "conditions": [
+            "cond_public"
+          ],
+          "returnValue": true,
+          "id": "public_rule",
+          "salt": "",
+          "idType": "userID"
+        }
+      ],
+      "idType": "userID",
+      "entity": "segment",
+      "version": 1
+    }
+  },
+  "dynamic_configs": {
+    "test_experiment": {
+      "type": "dynamic_config",
+      "salt": "experiment-salt",
+      "enabled": true,
+      "defaultValue": {
+        "pricing_treatment_group": "control"
+      },
+      "rules": [
+        {
+          "name": "experimentAssignment",
+          "passPercentage": 100,
+          "conditions": [
+            "cond_public"
+          ],
+          "returnValue": {
+            "pricing_treatment_group": "control"
+          },
+          "id": "experimentAssignment",
+          "salt": "",
+          "idType": "userID"
+        },
+        {
+          "name": "control_group",
+          "groupName": "Control",
+          "passPercentage": 100,
+          "conditions": [
+            "cond_public"
+          ],
+          "returnValue": {
+            "pricing_treatment_group": "control"
+          },
+          "id": "control_group",
+          "salt": "control_group",
+          "idType": "userID",
+          "isExperimentGroup": true
+        }
+      ],
+      "idType": "userID",
+      "entity": "experiment",
+      "hasSharedParams": true,
+      "isActive": true,
+      "version": 1,
+      "explicitParameters": [
+        "pricing_treatment_group"
+      ]
+    },
+    "test_experiment_treatment": {
+      "type": "dynamic_config",
+      "salt": "experiment-treatment-salt",
+      "enabled": true,
+      "defaultValue": {
+        "pricing_treatment_group": "treatment"
+      },
+      "rules": [
+        {
+          "name": "treatment_group",
+          "groupName": "Test",
+          "passPercentage": 100,
+          "conditions": [
+            "cond_public"
+          ],
+          "returnValue": {
+            "pricing_treatment_group": "treatment"
+          },
+          "id": "treatment_group",
+          "salt": "treatment_group",
+          "idType": "userID",
+          "isExperimentGroup": true
+        }
+      ],
+      "idType": "userID",
+      "entity": "experiment",
+      "hasSharedParams": true,
+      "isActive": true,
+      "version": 1,
+      "explicitParameters": [
+        "pricing_treatment_group"
+      ]
+    }
+  },
+  "layer_configs": {
+    "test_layer": {
+      "type": "dynamic_config",
+      "salt": "layer-salt",
+      "enabled": true,
+      "defaultValue": {
+        "pricing_treatment_group": "control"
+      },
+      "rules": [
+        {
+          "name": "experimentAssignment",
+          "passPercentage": 100,
+          "conditions": [
+            "cond_public"
+          ],
+          "returnValue": {
+            "pricing_treatment_group": "control"
+          },
+          "id": "experimentAssignment",
+          "salt": "",
+          "idType": "userID",
+          "configDelegate": "test_experiment"
+        }
+      ],
+      "idType": "userID",
+      "entity": "layer",
+      "version": 1
+    }
+  },
+  "condition_map": {
+    "cond_public": {
+      "type": "public",
+      "targetValue": null,
+      "operator": null,
+      "field": null,
+      "additionalValues": null,
+      "idType": "userID"
+    },
+    "cond_pass_segment_gate": {
+      "type": "pass_gate",
+      "targetValue": "segment:test_id_list_segment",
+      "operator": null,
+      "field": null,
+      "additionalValues": {},
+      "idType": "userID"
+    },
+    "cond_pass_always_gate": {
+      "type": "pass_gate",
+      "targetValue": "always_pass_gate",
+      "operator": null,
+      "field": null,
+      "additionalValues": {},
+      "idType": "userID"
+    },
+    "cond_in_segment_list": {
+      "type": "user_field",
+      "targetValue": [
+        "user_in_segment"
+      ],
+      "operator": "any",
+      "field": "userID",
+      "additionalValues": {},
+      "idType": "userID"
+    }
+  },
+  "experiment_to_layer": {
+    "test_experiment": "test_layer",
+    "test_experiment_treatment": "test_layer"
+  },
+  "overrides": {
+    "test_layer": [
+      {
+        "new_config_name": "test_experiment_treatment",
+        "rules": [
+          {
+            "rule_name": "segment_override_rule"
+          }
+        ]
+      }
+    ]
+  },
+  "override_rules": {
+    "segment_override_rule": {
+      "name": "segment_override_rule",
+      "passPercentage": 100,
+      "conditions": [
+        "cond_pass_always_gate"
+      ],
+      "returnValue": true,
+      "id": "segment_override_rule",
+      "salt": "",
+      "idType": "userID"
+    }
+  }
+}

--- a/statsig-rust/tests/layer_conditional_override_tests.rs
+++ b/statsig-rust/tests/layer_conditional_override_tests.rs
@@ -1,0 +1,68 @@
+mod utils;
+
+use crate::utils::mock_event_logging_adapter::MockEventLoggingAdapter;
+use crate::utils::mock_specs_adapter::MockSpecsAdapter;
+use statsig_rust::{Statsig, StatsigOptions, StatsigUser};
+use std::sync::Arc;
+
+async fn setup() -> Statsig {
+    let options = StatsigOptions {
+        specs_adapter: Some(Arc::new(MockSpecsAdapter::with_data(
+            "tests/data/layer_conditional_override_dcs.json",
+        ))),
+        event_logging_adapter: Some(Arc::new(MockEventLoggingAdapter::new())),
+        ..StatsigOptions::default()
+    };
+
+    let statsig = Statsig::new("secret-key", Some(Arc::new(options)));
+    statsig.initialize().await.unwrap();
+    statsig
+}
+
+/// Reproduces a bug where layer conditional overrides (the `overrides` /
+/// `override_rules` fields in the DCS response) fail to resolve when the
+/// override's `new_config_name` refers to an experiment (stored in
+/// `dynamic_configs`).
+///
+/// `try_apply_config_mapping` passes the caller's `spec_type` through to
+/// `Evaluator::evaluate`. When the original evaluation is for a *layer*
+/// (`SpecType::Layer`), the recursive call looks up `new_config_name` in
+/// `layer_configs` instead of `dynamic_configs`, so the experiment is never
+/// found and the override silently fails.
+///
+/// The test sets up:
+///   - A layer `test_layer` that normally delegates to `test_experiment`
+///     (which returns `pricing_treatment_group = "control"`)
+///   - A conditional override on the layer that, when matched, should
+///     redirect to `test_experiment_treatment`
+///     (which returns `pricing_treatment_group = "treatment"`)
+///   - The override rule uses `always_pass_gate` (a public gate) so
+///     the condition always passes — isolating the lookup bug from any
+///     segment/ID-list issues.
+///
+/// Expected: the override fires and the user gets "treatment".
+/// Actual (buggy): the override is silently skipped and the user gets
+/// "control" from normal layer delegation.
+#[tokio::test]
+async fn test_layer_conditional_override_resolves_experiment() {
+    let statsig = setup().await;
+    let user = StatsigUser::with_user_id("test_user".to_string());
+
+    let layer = statsig.get_layer(&user, "test_layer");
+
+    let treatment_group = layer.get::<String>("pricing_treatment_group", "".to_string());
+
+    // The conditional override should fire (the gate always passes) and
+    // redirect to test_experiment_treatment which returns "treatment".
+    // Due to the spec_type bug, the experiment lookup fails silently and
+    // we fall through to the normal delegation which returns "control".
+    assert_eq!(
+        treatment_group, "treatment",
+        "Layer conditional override should resolve the experiment from dynamic_configs. \
+         Got 'control' instead, which means try_apply_config_mapping failed to find \
+         new_config_name='test_experiment_treatment' because it was looked up in \
+         layer_configs (SpecType::Layer) instead of dynamic_configs (SpecType::Experiment)."
+    );
+
+    statsig.shutdown().await.unwrap();
+}


### PR DESCRIPTION
This one came up in a prod on a test account. The code change is clauded but looks right to me - opening to demonstrate what we think the problem/fix is - take it at face value and close or do something else if more useful, or merge if fine.

Issue that lead here - 
We have config that we think is correct, but are getting a control allocation when we'd expect a treatment.
What we saw was that for 9451d929e6243fa3e883048f1fcfd36c

We evaluated against https://console.statsig.com/6cg6VdWIzlGm38eE3ePry2/experiments/pricing_usa-usa_p2p_dec25/results and got C

Despite having the user in this segment: https://console.statsig.com/6cg6VdWIzlGm38eE3ePry2/segments/segment%3Ap2p_send_via_link_feature_arg_test_audience

Which is set up as a conditional override to T for the layer containing that experiment https://console.statsig.com/6cg6VdWIzlGm38eE3ePry2/layers/pricing_experiments_usa-usa

We think there might be an issue with the quoteservice javacore sdk on version 0.6.1 (fairly behind latest) where it's not processing conditional layer overrides correctly. On updating to 0.15.1 we still got a repro - then looking at the code found what looks like a bug where the server core code does not handle conditional overrides from layers -> experiments correctly, nor test for it. 

`try_apply_config_mapping` passes the caller's `spec_type` through to the recursive `Evaluator::evaluate` call. When evaluating a layer (`SpecType::Layer`), the override's `new_config_name` — which refers to an experiment in `dynamic_configs` — is looked up in `layer_configs` instead, returning `Unrecognized`. The override is silently dropped and the user falls through to normal layer delegation.

Fix: when `spec_type` is `Layer`, resolve the override target as `SpecType::Experiment`, matching what `evaluate_config_delegate` already does for normal layer-to-experiment delegation. Other spec types (gates, experiments) continue to pass through unchanged.

Includes a failing test and DCS fixture that reproduces the bug.