### PR TITLE
[feat] Java Core - add native Statsig forward proxy support

### DIFF
--- a/cli/src/commands/builders/builder-options.ts
+++ b/cli/src/commands/builders/builder-options.ts
@@ -11,5 +11,6 @@ export type BuilderOptions = {
   docker: boolean;
   subProject?: string;
   envSetupForBuild?: string; // Setup env variable to run build, e.g. RUSTFLAGS=""
+  cargoFeatures?: string[];
   sign?: boolean;
 };

--- a/cli/src/commands/builders/java-builder.ts
+++ b/cli/src/commands/builders/java-builder.ts
@@ -17,6 +17,7 @@ export function buildJava(options: BuilderOptions) {
 
   options.release = true; // default to true
   options.targetProject = 'statsig_java';
+  options.cargoFeatures = ['with_grpc'];
   options.target = detectTarget(options);
   buildFfiHelper(options);
   Log.stepEnd(`Built statsig-java`);

--- a/cli/src/commands/publishers/java-publisher.ts
+++ b/cli/src/commands/publishers/java-publisher.ts
@@ -27,11 +27,23 @@ const JAVA_NATIVE_DIR = path.resolve(
 );
 
 export async function javaPublish(options: PublisherOptions) {
-  const libFiles = [
+  const allLibFiles = [
     ...listFiles(options.workingDir, '**/target/**/release/*.dylib'),
     ...listFiles(options.workingDir, '**/target/**/release/*.so'),
     ...listFiles(options.workingDir, '**/target/**/release/*.dll'),
   ].filter(isMappedTarget);
+  const javaLibFiles = allLibFiles.filter(
+    (file) => file.includes('-java/') || file.includes('-java\\'),
+  );
+  const libFiles = javaLibFiles.length > 0 ? javaLibFiles : allLibFiles;
+
+  if (javaLibFiles.length > 0) {
+    Log.stepProgress('Using Java package native artifacts for publishing');
+  } else {
+    Log.stepProgress(
+      'Java package artifacts not found, falling back to generic FFI artifacts',
+    );
+  }
 
   Log.stepBegin('Clearing Java Native Directory');
   ensureEmptyDir(JAVA_NATIVE_DIR);

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -58,7 +58,7 @@ const TEST_COMMANDS: Record<string, string> = {
   ].join(' && '),
 
   java: [
-    'cargo build -p statsig_ffi',
+    'cargo build -p statsig_ffi --features with_grpc',
 
     'rm -rf statsig-java/src/main/resources/native',
 

--- a/cli/src/utils/ffi_utils.ts
+++ b/cli/src/utils/ffi_utils.ts
@@ -163,6 +163,9 @@ export function buildFfiHelper(options: BuilderOptions) {
   const buildConfigs = [`-p statsig_ffi`,
     options.release ? '--release' : '',
     `--target-dir target/${outDir}`]
+  if ((options.cargoFeatures?.length ?? 0) > 0) {
+    buildConfigs.push(`--features "${options.cargoFeatures!.join(' ')}"`)
+  }
   let command = "";
   if (shouldUseCross) {
     buildConfigs.push(`--target ${options.target!}`)

--- a/statsig-ffi/Cargo.toml
+++ b/statsig-ffi/Cargo.toml
@@ -32,3 +32,4 @@ path = "tests/main.rs"
 
 [features]
 default = []
+with_grpc = ["statsig-rust/with_grpc"]

--- a/statsig-java/src/main/java/com/statsig/AuthenticationMode.java
+++ b/statsig-java/src/main/java/com/statsig/AuthenticationMode.java
@@ -1,0 +1,9 @@
+package com.statsig;
+
+public final class AuthenticationMode {
+  public static final String NONE = "none";
+  public static final String TLS = "tls";
+  public static final String MTLS = "mtls";
+
+  private AuthenticationMode() {}
+}

--- a/statsig-java/src/main/java/com/statsig/SpecAdapterType.java
+++ b/statsig-java/src/main/java/com/statsig/SpecAdapterType.java
@@ -1,0 +1,9 @@
+package com.statsig;
+
+public final class SpecAdapterType {
+  public static final String DATA_STORE = "data_store";
+  public static final String NETWORK_HTTP = "network_http";
+  public static final String NETWORK_GRPC_WEBSOCKET = "network_grpc_websocket";
+
+  private SpecAdapterType() {}
+}

--- a/statsig-java/src/test/java/com/statsig/SpecAdapterConfigTest.java
+++ b/statsig-java/src/test/java/com/statsig/SpecAdapterConfigTest.java
@@ -11,19 +11,19 @@ public class SpecAdapterConfigTest {
   public void testSetterChainingAndGetters() {
     SpecAdapterConfig config =
         new SpecAdapterConfig()
-            .setAdapterType("http")
+            .setAdapterType(SpecAdapterType.NETWORK_HTTP)
             .setSpecsUrl("https://example.com/specs")
             .setInitTimeoutMs(2000L)
-            .setAuthenticationMode("mtls")
+            .setAuthenticationMode(AuthenticationMode.MTLS)
             .setCaCertPath("/path/to/ca")
             .setClientCertPath("/path/to/client")
             .setClientKeyPath("/path/to/key")
             .setDomainName("example.com");
 
-    assertEquals("http", config.getAdapterType());
+    assertEquals(SpecAdapterType.NETWORK_HTTP, config.getAdapterType());
     assertEquals("https://example.com/specs", config.getSpecsUrl());
     assertEquals(2000L, config.getInitTimeoutMs());
-    assertEquals("mtls", config.getAuthenticationMode());
+    assertEquals(AuthenticationMode.MTLS, config.getAuthenticationMode());
     assertEquals("/path/to/ca", config.getCaCertPath());
     assertEquals("/path/to/client", config.getClientCertPath());
     assertEquals("/path/to/key", config.getClientKeyPath());
@@ -33,8 +33,18 @@ public class SpecAdapterConfigTest {
   @Test
   public void testSettersReturnSameInstance() {
     SpecAdapterConfig config = new SpecAdapterConfig();
-    assertSame(config, config.setAdapterType("http"));
+    assertSame(config, config.setAdapterType(SpecAdapterType.NETWORK_HTTP));
     assertSame(config, config.setSpecsUrl("https://example.com/specs"));
     assertSame(config, config.setInitTimeoutMs(1234L));
+  }
+
+  @Test
+  public void testTypedConstantsExposeCanonicalValues() {
+    assertEquals("data_store", SpecAdapterType.DATA_STORE);
+    assertEquals("network_http", SpecAdapterType.NETWORK_HTTP);
+    assertEquals("network_grpc_websocket", SpecAdapterType.NETWORK_GRPC_WEBSOCKET);
+    assertEquals("none", AuthenticationMode.NONE);
+    assertEquals("tls", AuthenticationMode.TLS);
+    assertEquals("mtls", AuthenticationMode.MTLS);
   }
 }

--- a/statsig-java/src/test/java/com/statsig/StatsigOptionsTest.java
+++ b/statsig-java/src/test/java/com/statsig/StatsigOptionsTest.java
@@ -132,15 +132,16 @@ public class StatsigOptionsTest {
   void testBuilderWithSpecAdapterConfigs() {
     SpecAdapterConfig httpConfig =
         new SpecAdapterConfig()
-            .setAdapterType("http")
+            .setAdapterType(SpecAdapterType.NETWORK_HTTP)
             .setSpecsUrl("https://example.com/http")
             .setInitTimeoutMs(1234L)
-            .setAuthenticationMode("none");
+            .setAuthenticationMode(AuthenticationMode.NONE);
     SpecAdapterConfig grpcConfig =
         new SpecAdapterConfig()
-            .setAdapterType("grpc")
+            .setAdapterType(SpecAdapterType.NETWORK_GRPC_WEBSOCKET)
             .setSpecsUrl("https://example.com/grpc")
             .setInitTimeoutMs(5678L)
+            .setAuthenticationMode(AuthenticationMode.MTLS)
             .setCaCertPath("/path/ca")
             .setClientCertPath("/path/client")
             .setClientKeyPath("/path/key")
@@ -151,6 +152,21 @@ public class StatsigOptionsTest {
             .setSpecAdapterConfigs(Arrays.asList(httpConfig, grpcConfig))
             .setSpecsUrl("https://fallback.specs")
             .build();
+  }
+
+  @Test
+  void testBuilderWithGrpcSpecAdapterConfigAndTlsFields() {
+    SpecAdapterConfig grpcConfig =
+        new SpecAdapterConfig()
+            .setAdapterType(SpecAdapterType.NETWORK_GRPC_WEBSOCKET)
+            .setSpecsUrl("https://forward-proxy.example.com")
+            .setInitTimeoutMs(4000L)
+            .setAuthenticationMode(AuthenticationMode.TLS)
+            .setCaCertPath("/path/to/ca.pem")
+            .setDomainName("forward-proxy.example.com");
+
+    StatsigOptions options =
+        new StatsigOptions.Builder().setSpecAdapterConfigs(Arrays.asList(grpcConfig)).build();
   }
 
   @Test


### PR DESCRIPTION
## Summary

This updates Java Core so the existing `SpecAdapterConfig` path can be used for native forward proxy support with the gRPC websocket adapter.

The main changes are:
- add typed Java constants for spec adapter types and authentication modes
- enable `with_grpc` in the Java FFI build path
- update Java build/test/publish flows to produce grpc-enabled native artifacts
- update Java tests to use the canonical adapter names that Rust already expects

This PR does not add a new forward-proxy-specific Java API. It keeps `SpecAdapterConfig` and `setSpecAdapterConfigs(...)` as the public surface.

## Changes

- Added Java constants:
  - `SpecAdapterType.DATA_STORE`
  - `SpecAdapterType.NETWORK_HTTP`
  - `SpecAdapterType.NETWORK_GRPC_WEBSOCKET`
  - `AuthenticationMode.NONE`
  - `AuthenticationMode.TLS`
  - `AuthenticationMode.MTLS`
- Updated Java tests to use canonical adapter values instead of legacy `"http"` / `"grpc"` strings
- Added Java-side coverage for grpc-websocket config construction with TLS fields
- Added `with_grpc` feature forwarding in `statsig-ffi`
- Updated the active Java build/test/publish paths to build `statsig_ffi` with `with_grpc`
- Kept `ProxyConfig` unchanged; this remains generic outbound HTTP proxy config only

## Verification

Successful testing completed locally:

- `./tore test java --no-docker`
  - passed under Java 11

- `./tore build java --os macos --arch arm64 --skip-docker-build`
  - passed
  - grpc-enabled native artifact was produced for the Java package

- Local forward proxy validation against a running proxy
  - plaintext gRPC on `http://127.0.0.1:50051`
  - TLS on `https://127.0.0.1:50052`
  - mTLS on `https://127.0.0.1:50052`

For the local forward proxy runtime validation, Java Core successfully:
- initialized through `network_grpc_websocket`
- loaded config specs from the proxy
- reported `configSpecReady=true`
- completed a basic evaluation successfully

Additional local validation:
- generated and validated local CA/server/client certs
- verified the TLS listener with `openssl s_client`
- confirmed proxy-side gRPC initialization logs during Java client startup
