### PR TITLE
[codex] Use IndexMap for user data maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ dependencies = [
  "file-guard",
  "flate2",
  "futures",
+ "indexmap 2.13.0",
  "lazy_static",
  "libc",
  "log",

--- a/examples/rust/mem-bench/Cargo.lock
+++ b/examples/rust/mem-bench/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +201,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +256,29 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytes"
@@ -567,7 +611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -761,7 +816,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -792,9 +847,21 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1114,13 +1181,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1173,29 +1241,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lazy-regex"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn",
 ]
 
 [[package]]
@@ -1272,6 +1317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1365,26 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-conv"
@@ -1358,6 +1432,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -1497,6 +1595,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,7 +1623,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -1548,6 +1659,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1638,6 +1769,15 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -1757,6 +1897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1916,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1816,6 +1966,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,7 +2026,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1961,6 +2141,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "ryu",
@@ -1989,7 +2170,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2015,7 +2196,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2047,6 +2228,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_logger"
@@ -2102,8 +2289,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "statsig-rust"
-version = "0.12.2-rc.2511180139"
+version = "0.19.1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2113,19 +2306,22 @@ dependencies = [
  "bytes",
  "chrono",
  "dashmap",
+ "fancy-regex",
  "file-guard",
  "flate2",
  "futures",
- "lazy-regex",
+ "indexmap 2.14.0",
  "lazy_static",
  "libc",
  "log",
+ "memmap2",
+ "ouroboros",
  "parking_lot",
  "percent-encoding",
  "prost",
  "rand 0.8.5",
- "regex",
  "reqwest",
+ "rkyv",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2194,7 +2390,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2413,7 +2609,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3048,6 +3244,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/examples/rust/mem-bench/benches/main_benches.rs
+++ b/examples/rust/mem-bench/benches/main_benches.rs
@@ -2,13 +2,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use mem_bench::noop_event_logging_adapter::NoopEventLoggingAdapter;
 use mem_bench::static_specs_adapter::StaticSpecsAdapter;
 use statsig_rust::user::user_data::UserData;
-use statsig_rust::{dyn_value, Statsig, StatsigOptions, StatsigUser};
-use std::collections::HashMap;
+use statsig_rust::{dyn_value, Statsig, StatsigOptions, StatsigUser, StatsigUserDataMap};
 use std::sync::Arc;
 
 fn create_user() -> StatsigUser {
-    StatsigUser {
-      data: Arc::new(UserData {
+    StatsigUser::new(UserData {
         user_id: Some(dyn_value!("a_user")),
         email: Some(dyn_value!("daniel@statsig.com")),
         ip: Some(dyn_value!("127.0.0.1")),
@@ -16,20 +14,20 @@ fn create_user() -> StatsigUser {
         country: Some(dyn_value!("US")),
         locale: Some(dyn_value!("en-US")),
         app_version: Some(dyn_value!("1.0.0")),
-        custom_ids: Some(HashMap::from([
+        custom_ids: Some(StatsigUserDataMap::from([
             ("companyID".into(), dyn_value!("statsig")),
-            ("groupID".to_string(), dyn_value!("sdk_team"),
-        )])),
-        custom: Some(HashMap::from([(
+            ("groupID".to_string(), dyn_value!("sdk_team")),
+        ])),
+        custom: Some(StatsigUserDataMap::from([(
             "test_custom_field".to_string(),
             dyn_value!("test_custom_field_value"),
         )])),
-        private_attributes: Some(HashMap::from([(
+        private_attributes: Some(StatsigUserDataMap::from([(
             "test_private_attribute".to_string(),
             dyn_value!("test_private_attribute_value"),
         )])),
-      })
-    }
+        ..Default::default()
+    })
 }
 
 async fn setup() -> (StatsigUser, Statsig) {

--- a/examples/rust/mem-bench/src/bin/gate-mem.rs
+++ b/examples/rust/mem-bench/src/bin/gate-mem.rs
@@ -3,9 +3,9 @@ use mem_bench::{
 };
 use statsig_rust::{
     dyn_value, user::user_data::UserData, Statsig, StatsigOptions, StatsigRuntime, StatsigUser,
+    StatsigUserDataMap,
 };
 use std::{
-    collections::HashMap,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -93,31 +93,29 @@ async fn profile_gate_checks(gate_names: &[String]) {
 }
 
 fn create_user() -> StatsigUser {
-    StatsigUser {
-        data: Arc::new(UserData {
-            user_id: Some(dyn_value!("a_user")),
-            email: Some(dyn_value!("daniel@statsig.com")),
-            ip: Some(dyn_value!("127.0.0.1")),
-            user_agent: Some("Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1".into()),
-            country: Some(dyn_value!("US")),
-            locale: Some(dyn_value!("en-US")),
-            app_version: Some(dyn_value!("1.0.0")),
-            custom_ids: Some(HashMap::from([
-                ("companyID".into(), dyn_value!("statsig")),
-                ("groupID".to_string(), dyn_value!("sdk_team"),
-            )])),
-            custom: Some(HashMap::from([(
-                "test_custom_field".to_string(),
-                dyn_value!("test_custom_field_value"),
-            )])),
-            private_attributes: Some(HashMap::from([(
-                "test_private_attribute".to_string(),
-                dyn_value!("test_private_attribute_value"),
-            )])),
-            statsig_environment: Some(HashMap::from([(
-                "tier".to_string(),
-                dyn_value!("development"),
-            )])),
-        }),
-    }
+    StatsigUser::new(UserData {
+        user_id: Some(dyn_value!("a_user")),
+        email: Some(dyn_value!("daniel@statsig.com")),
+        ip: Some(dyn_value!("127.0.0.1")),
+        user_agent: Some("Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1".into()),
+        country: Some(dyn_value!("US")),
+        locale: Some(dyn_value!("en-US")),
+        app_version: Some(dyn_value!("1.0.0")),
+        custom_ids: Some(StatsigUserDataMap::from([
+            ("companyID".into(), dyn_value!("statsig")),
+            ("groupID".to_string(), dyn_value!("sdk_team")),
+        ])),
+        custom: Some(StatsigUserDataMap::from([(
+            "test_custom_field".to_string(),
+            dyn_value!("test_custom_field_value"),
+        )])),
+        private_attributes: Some(StatsigUserDataMap::from([(
+            "test_private_attribute".to_string(),
+            dyn_value!("test_private_attribute_value"),
+        )])),
+        statsig_environment: Some(StatsigUserDataMap::from([(
+            "tier".to_string(),
+            dyn_value!("development"),
+        )])),
+    })
 }

--- a/statsig-rust/Cargo.toml
+++ b/statsig-rust/Cargo.toml
@@ -17,6 +17,7 @@ dashmap = "6.1.0"
 file-guard = "0.2.0"
 flate2 = "1.0.35"
 futures = "0.3.30"
+indexmap = { version = "2.13.0", features = ["serde"] }
 lazy_static = "1.5.0"
 log = "0.4.22"
 parking_lot = "0.12.1"

--- a/statsig-rust/src/console_capture/console_capture_instances.rs
+++ b/statsig-rust/src/console_capture/console_capture_instances.rs
@@ -8,8 +8,10 @@ use crate::console_capture::console_log_line_levels::StatsigLogLineLevel;
 use parking_lot::RwLock;
 
 use crate::{
-    log_e, observability::ops_stats::OpsStatsForInstance, user::StatsigUserLoggable, DynamicValue,
-    StatsigOptions, OPS_STATS,
+    log_e,
+    observability::ops_stats::OpsStatsForInstance,
+    user::{user_data::UserDataMap, StatsigUserLoggable},
+    DynamicValue, StatsigOptions, OPS_STATS,
 };
 
 const TAG: &str = stringify!(ConsoleCaptureRegistry);
@@ -51,13 +53,19 @@ impl ConsoleCaptureInstance {
         let loggable_user = if let Some(console_capture_user) = console_capture_options.user {
             StatsigUserLoggable::new(
                 &console_capture_user.data,
-                environment.clone(),
-                statsig_options.global_custom_fields.clone(),
+                environment.as_ref().map(clone_to_user_data_map),
+                statsig_options
+                    .global_custom_fields
+                    .as_ref()
+                    .map(clone_to_user_data_map),
             )
         } else {
             StatsigUserLoggable::default_console_capture_user(
-                environment.clone(),
-                statsig_options.global_custom_fields.clone(),
+                environment.as_ref().map(clone_to_user_data_map),
+                statsig_options
+                    .global_custom_fields
+                    .as_ref()
+                    .map(clone_to_user_data_map),
             )
         };
 
@@ -72,6 +80,10 @@ impl ConsoleCaptureInstance {
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
+}
+
+fn clone_to_user_data_map(map: &HashMap<String, DynamicValue>) -> UserDataMap {
+    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
 }
 
 impl ConsoleCaptureRegistry {

--- a/statsig-rust/src/lib.rs
+++ b/statsig-rust/src/lib.rs
@@ -29,7 +29,10 @@ pub use statsig_core_api_options::{
 pub use statsig_err::StatsigErr;
 pub use statsig_options::StatsigOptions;
 pub use statsig_runtime::StatsigRuntime;
-pub use user::user_data::UserData as StatsigUserData;
+pub use user::user_data::{
+    IntoOptionalUserDataMap, IntoUserDataMap, UserData as StatsigUserData,
+    UserDataMap as StatsigUserDataMap,
+};
 pub use user::{StatsigUser, StatsigUserBuilder};
 
 pub mod compression;

--- a/statsig-rust/src/user/statsig_user.rs
+++ b/statsig-rust/src/user/statsig_user.rs
@@ -1,9 +1,14 @@
 use crate::evaluation::dynamic_value::DynamicValue;
 use crate::statsig_metadata;
 use crate::{dyn_value, evaluation::dynamic_string::DynamicString};
-use std::{collections::HashMap, sync::Arc};
+use indexmap::IndexMap;
+use std::sync::Arc;
 
-use super::{into_optional::IntoOptional, unit_id::UnitID, user_data::UserData};
+use super::{
+    into_optional::IntoOptional,
+    unit_id::UnitID,
+    user_data::{IntoOptionalUserDataMap, UserData, UserDataMap},
+};
 
 #[derive(Clone)]
 pub struct StatsigUser {
@@ -23,12 +28,13 @@ impl StatsigUser {
     }
 
     #[must_use]
-    pub fn with_custom_ids<K, U>(custom_ids: HashMap<K, U>) -> Self
+    pub fn with_custom_ids<K, U, I>(custom_ids: I) -> Self
     where
+        I: IntoIterator<Item = (K, U)>,
         K: Into<String>,
         U: Into<UnitID>,
     {
-        let custom_ids: HashMap<String, DynamicValue> = custom_ids
+        let custom_ids: UserDataMap = custom_ids
             .into_iter()
             .map(|(k, v)| (k.into(), v.into().into()))
             .collect();
@@ -75,17 +81,13 @@ macro_rules! string_field_accessor {
 
 macro_rules! map_field_accessor {
     ($self:ident, $getter_name:ident, $setter_name:ident, $field:ident) => {
-        pub fn $getter_name(&self) -> Option<&HashMap<String, DynamicValue>> {
+        pub fn $getter_name(&self) -> Option<&UserDataMap> {
             self.data.$field.as_ref()
         }
 
-        pub fn $setter_name<K, V>(&mut self, value: impl IntoOptional<HashMap<K, V>>)
-        where
-            K: Into<String>,
-            V: Into<DynamicValue>,
-        {
+        pub fn $setter_name(&mut self, value: impl IntoOptionalUserDataMap) {
             let mut_data = Arc::make_mut(&mut self.data);
-            let value = match value.into_optional() {
+            let value = match value.into_optional_user_data_map() {
                 Some(value) => value,
                 None => {
                     mut_data.$field = None;
@@ -93,12 +95,7 @@ macro_rules! map_field_accessor {
                 }
             };
 
-            mut_data.$field = Some(
-                value
-                    .into_iter()
-                    .map(|(k, v)| (k.into(), v.into()))
-                    .collect(),
-            );
+            mut_data.$field = Some(value);
         }
     };
 }
@@ -123,7 +120,7 @@ impl StatsigUser {
 
     // ---------------------------------------- [Custom IDs]
 
-    pub fn get_custom_ids(&self) -> Option<HashMap<&str, &str>> {
+    pub fn get_custom_ids(&self) -> Option<IndexMap<&str, &str>> {
         let mapped = self
             .data
             .custom_ids
@@ -135,8 +132,9 @@ impl StatsigUser {
         Some(mapped)
     }
 
-    pub fn set_custom_ids<K, U>(&mut self, custom_ids: HashMap<K, U>)
+    pub fn set_custom_ids<K, U, I>(&mut self, custom_ids: I)
     where
+        I: IntoIterator<Item = (K, U)>,
         K: Into<String>,
         U: Into<UnitID>,
     {
@@ -167,7 +165,7 @@ impl StatsigUser {
 
     // ---------------------------------------- [ Statsig Environment ]
 
-    pub fn get_statsig_environment(&self) -> Option<HashMap<&str, &str>> {
+    pub fn get_statsig_environment(&self) -> Option<IndexMap<&str, &str>> {
         let mapped = self
             .data
             .statsig_environment
@@ -179,8 +177,9 @@ impl StatsigUser {
         Some(mapped)
     }
 
-    pub fn set_statsig_environment<K, U>(&mut self, statsig_environment: Option<HashMap<K, U>>)
+    pub fn set_statsig_environment<K, U, I>(&mut self, statsig_environment: Option<I>)
     where
+        I: IntoIterator<Item = (K, U)>,
         K: Into<String>,
         U: Into<String>,
     {
@@ -194,7 +193,7 @@ impl StatsigUser {
             }
         };
 
-        let statsig_environment: HashMap<String, DynamicValue> = statsig_environment
+        let statsig_environment: UserDataMap = statsig_environment
             .into_iter()
             .map(|(k, v)| (k.into(), v.into().into()))
             .collect();

--- a/statsig-rust/src/user/statsig_user_builder.rs
+++ b/statsig-rust/src/user/statsig_user_builder.rs
@@ -1,13 +1,14 @@
 use super::unit_id::UnitID;
-use super::user_data::UserData;
+use super::user_data::{UserData, UserDataMap};
 use super::StatsigUser;
 use crate::dyn_value;
 use crate::evaluation::dynamic_value::DynamicValue;
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 pub struct StatsigUserBuilder {
     pub user_id: Option<UnitID>,
-    pub custom_ids: Option<HashMap<String, UnitID>>,
+    pub custom_ids: Option<IndexMap<String, UnitID>>,
 
     pub email: Option<DynamicValue>,
     pub ip: Option<DynamicValue>,
@@ -16,10 +17,10 @@ pub struct StatsigUserBuilder {
     pub locale: Option<DynamicValue>,
     pub app_version: Option<DynamicValue>,
 
-    pub custom: Option<HashMap<String, DynamicValue>>,
-    pub private_attributes: Option<HashMap<String, DynamicValue>>,
+    pub custom: Option<UserDataMap>,
+    pub private_attributes: Option<UserDataMap>,
 
-    pub statsig_environment: Option<HashMap<String, DynamicValue>>,
+    pub statsig_environment: Option<UserDataMap>,
 }
 
 impl StatsigUserBuilder {
@@ -32,8 +33,9 @@ impl StatsigUserBuilder {
     }
 
     #[must_use]
-    pub fn new_with_custom_ids<K, U>(custom_ids: HashMap<K, U>) -> Self
+    pub fn new_with_custom_ids<K, U, I>(custom_ids: I) -> Self
     where
+        I: IntoIterator<Item = (K, U)>,
         K: Into<String>,
         U: Into<UnitID>,
     {
@@ -63,10 +65,12 @@ impl StatsigUserBuilder {
         self
     }
 
-    pub fn custom_ids(
-        mut self,
-        custom_ids: Option<HashMap<impl Into<String>, impl Into<UnitID>>>,
-    ) -> Self {
+    pub fn custom_ids<K, U, I>(mut self, custom_ids: Option<I>) -> Self
+    where
+        I: IntoIterator<Item = (K, U)>,
+        K: Into<String>,
+        U: Into<UnitID>,
+    {
         if let Some(custom_ids) = custom_ids {
             self.custom_ids = Some(
                 custom_ids
@@ -120,10 +124,12 @@ impl StatsigUserBuilder {
         self
     }
 
-    pub fn statsig_environment(
-        mut self,
-        statsig_environment: Option<HashMap<String, String>>,
-    ) -> Self {
+    pub fn statsig_environment<K, V, I>(mut self, statsig_environment: Option<I>) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
         if let Some(statsig_environment) = statsig_environment {
             self.statsig_environment = Some(convert_str_map_to_dyn_values(statsig_environment));
         }
@@ -131,7 +137,12 @@ impl StatsigUserBuilder {
     }
 
     // todo: support HashMap<String, String | Number | Boolean | Array<String>>
-    pub fn custom_from_str_map(mut self, custom: Option<HashMap<String, String>>) -> Self {
+    pub fn custom_from_str_map<K, V, I>(mut self, custom: Option<I>) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
         if let Some(custom) = custom {
             self.custom = Some(convert_str_map_to_dyn_values(custom));
         }
@@ -140,16 +151,23 @@ impl StatsigUserBuilder {
 
     pub fn custom(mut self, custom: Option<HashMap<String, DynamicValue>>) -> Self {
         if let Some(custom) = custom {
-            self.custom = Some(custom);
+            self.custom = Some(
+                custom
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
+            );
         }
         self
     }
 
     // todo: support HashMap<String, String | Number | Boolean | Array<String>>
-    pub fn private_attributes_from_str_map(
-        mut self,
-        private_attributes: Option<HashMap<String, String>>,
-    ) -> Self {
+    pub fn private_attributes_from_str_map<K, V, I>(mut self, private_attributes: Option<I>) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
         if let Some(private_attributes) = private_attributes {
             self.private_attributes = Some(convert_str_map_to_dyn_values(private_attributes));
         }
@@ -161,7 +179,12 @@ impl StatsigUserBuilder {
         private_attributes: Option<HashMap<String, DynamicValue>>,
     ) -> Self {
         if let Some(private_attributes) = private_attributes {
-            self.private_attributes = Some(private_attributes);
+            self.private_attributes = Some(
+                private_attributes
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
+            );
         }
         self
     }
@@ -187,11 +210,14 @@ impl StatsigUserBuilder {
     }
 }
 
-fn convert_str_map_to_dyn_values(
-    custom_ids: HashMap<String, String>,
-) -> HashMap<String, DynamicValue> {
+fn convert_str_map_to_dyn_values<K, V, I>(custom_ids: I) -> UserDataMap
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
     custom_ids
         .into_iter()
-        .map(|(k, v)| (k, dyn_value!(v)))
+        .map(|(k, v)| (k.into(), dyn_value!(v.into())))
         .collect()
 }

--- a/statsig-rust/src/user/statsig_user_internal.rs
+++ b/statsig-rust/src/user/statsig_user_internal.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::Utc;
 
-use super::StatsigUserLoggable;
+use super::{user_data::UserDataMap, StatsigUserLoggable};
 use crate::evaluation::dynamic_value::DynamicValue;
 use crate::hashing::djb2_number;
 use crate::{evaluation::dynamic_string::DynamicString, Statsig};
@@ -137,13 +137,14 @@ impl<'statsig, 'user> StatsigUserInternal<'statsig, 'user> {
 
     pub fn to_loggable(&self) -> StatsigUserLoggable {
         let mut environment = self.user_ref.data.statsig_environment.clone();
-        let mut global_custom: Option<HashMap<String, DynamicValue>> = None;
+        let mut global_custom: Option<UserDataMap> = None;
 
         if let Some(statsig_instance) = &self.statsig_instance {
             if environment.is_none() {
-                environment = statsig_instance.use_statsig_env(|e| e.cloned());
+                environment = statsig_instance.use_statsig_env(|e| e.map(clone_to_user_data_map));
             }
-            global_custom = statsig_instance.use_global_custom_fields(|gc| gc.cloned());
+            global_custom =
+                statsig_instance.use_global_custom_fields(|gc| gc.map(clone_to_user_data_map));
         }
 
         StatsigUserLoggable::new(&self.user_ref.data, environment, global_custom)
@@ -170,6 +171,10 @@ impl<'statsig, 'user> StatsigUserInternal<'statsig, 'user> {
         }
         Some(val.to_string())
     }
+}
+
+fn clone_to_user_data_map(map: &HashMap<String, DynamicValue>) -> UserDataMap {
+    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
 }
 
 fn throttled_version_check(user: &StatsigUser) {

--- a/statsig-rust/src/user/statsig_user_loggable.rs
+++ b/statsig-rust/src/user/statsig_user_loggable.rs
@@ -1,23 +1,23 @@
-use super::user_data::UserData;
-use crate::{DynamicValue, StatsigUser};
+use super::user_data::{UserData, UserDataMap};
+use crate::StatsigUser;
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 const TAG: &str = "StatsigUserLoggable";
 
 #[derive(Clone, Default)]
 pub struct StatsigUserLoggable {
     pub data: Arc<UserData>,
-    pub environment: Option<HashMap<String, DynamicValue>>,
-    pub global_custom: Option<HashMap<String, DynamicValue>>,
+    pub environment: Option<UserDataMap>,
+    pub global_custom: Option<UserDataMap>,
 }
 
 impl StatsigUserLoggable {
     pub fn new(
         user_inner: &Arc<UserData>,
-        environment: Option<HashMap<String, DynamicValue>>,
-        global_custom: Option<HashMap<String, DynamicValue>>,
+        environment: Option<UserDataMap>,
+        global_custom: Option<UserDataMap>,
     ) -> Self {
         Self {
             data: user_inner.clone(),
@@ -31,8 +31,8 @@ impl StatsigUserLoggable {
     }
 
     pub fn default_console_capture_user(
-        environment: Option<HashMap<String, DynamicValue>>,
-        global_custom: Option<HashMap<String, DynamicValue>>,
+        environment: Option<UserDataMap>,
+        global_custom: Option<UserDataMap>,
     ) -> Self {
         Self::new(
             &StatsigUser::with_user_id("console-capture-user").data,
@@ -81,10 +81,9 @@ impl<'de> Deserialize<'de> for StatsigUserLoggable {
             serde::de::Error::custom(format!("Error deserializing StatsigUserInner: {e}"))
         })?;
 
-        let environment = serde_json::from_value::<Option<HashMap<String, DynamicValue>>>(env)
-            .map_err(|e| {
-                serde::de::Error::custom(format!("Error deserializing StatsigUserInner: {e}"))
-            })?;
+        let environment = serde_json::from_value::<Option<UserDataMap>>(env).map_err(|e| {
+            serde::de::Error::custom(format!("Error deserializing StatsigUserInner: {e}"))
+        })?;
 
         Ok(StatsigUserLoggable {
             data: Arc::new(data),
@@ -111,8 +110,8 @@ where
 
 fn serialize_custom_field<S>(
     state: &mut S,
-    custom: &Option<HashMap<String, DynamicValue>>,
-    global_custom: &Option<HashMap<String, DynamicValue>>,
+    custom: &Option<UserDataMap>,
+    global_custom: &Option<UserDataMap>,
 ) -> Result<(), S::Error>
 where
     S: SerializeStruct,
@@ -121,7 +120,7 @@ where
         return Ok(());
     }
 
-    let mut map = HashMap::new();
+    let mut map = indexmap::IndexMap::new();
 
     if let Some(global_custom) = global_custom.as_ref() {
         for (k, v) in global_custom {

--- a/statsig-rust/src/user/user_data.rs
+++ b/statsig-rust/src/user/user_data.rs
@@ -1,7 +1,146 @@
 use crate::{evaluation::dynamic_value::DynamicValue, hashing};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
+
+pub type UserDataMap = IndexMap<String, DynamicValue>;
+
+pub trait IntoUserDataMap {
+    fn into_user_data_map(self) -> UserDataMap;
+}
+
+pub trait IntoOptionalUserDataMap {
+    fn into_optional_user_data_map(self) -> Option<UserDataMap>;
+}
+
+impl<K, V> IntoUserDataMap for HashMap<K, V>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_user_data_map(self) -> UserDataMap {
+        self.into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+}
+
+impl<K, V> IntoOptionalUserDataMap for HashMap<K, V>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        Some(self.into_user_data_map())
+    }
+}
+
+impl<K, V> IntoOptionalUserDataMap for Option<HashMap<K, V>>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        self.map(IntoUserDataMap::into_user_data_map)
+    }
+}
+
+impl<K, V> IntoUserDataMap for IndexMap<K, V>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_user_data_map(self) -> UserDataMap {
+        self.into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+}
+
+impl<K, V> IntoOptionalUserDataMap for IndexMap<K, V>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        Some(self.into_user_data_map())
+    }
+}
+
+impl<K, V> IntoOptionalUserDataMap for Option<IndexMap<K, V>>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        self.map(IntoUserDataMap::into_user_data_map)
+    }
+}
+
+impl<K, V> IntoUserDataMap for Vec<(K, V)>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_user_data_map(self) -> UserDataMap {
+        self.into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+}
+
+impl<K, V> IntoOptionalUserDataMap for Vec<(K, V)>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        Some(self.into_user_data_map())
+    }
+}
+
+impl<K, V> IntoOptionalUserDataMap for Option<Vec<(K, V)>>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        self.map(IntoUserDataMap::into_user_data_map)
+    }
+}
+
+impl<K, V, const N: usize> IntoUserDataMap for [(K, V); N]
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_user_data_map(self) -> UserDataMap {
+        self.into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+}
+
+impl<K, V, const N: usize> IntoOptionalUserDataMap for [(K, V); N]
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        Some(self.into_user_data_map())
+    }
+}
+
+impl<K, V, const N: usize> IntoOptionalUserDataMap for Option<[(K, V); N]>
+where
+    K: Into<String>,
+    V: Into<DynamicValue>,
+{
+    fn into_optional_user_data_map(self) -> Option<UserDataMap> {
+        self.map(IntoUserDataMap::into_user_data_map)
+    }
+}
 
 #[skip_serializing_none]
 #[derive(Clone, Deserialize, Serialize, Default)]
@@ -10,7 +149,7 @@ pub struct UserData {
     #[serde(rename = "userID")]
     pub user_id: Option<DynamicValue>,
     #[serde(rename = "customIDs")]
-    pub custom_ids: Option<HashMap<String, DynamicValue>>,
+    pub custom_ids: Option<UserDataMap>,
 
     pub email: Option<DynamicValue>,
     pub ip: Option<DynamicValue>,
@@ -18,11 +157,11 @@ pub struct UserData {
     pub country: Option<DynamicValue>,
     pub locale: Option<DynamicValue>,
     pub app_version: Option<DynamicValue>,
-    pub statsig_environment: Option<HashMap<String, DynamicValue>>,
+    pub statsig_environment: Option<UserDataMap>,
 
     #[serde(skip_serializing)]
-    pub private_attributes: Option<HashMap<String, DynamicValue>>,
-    pub custom: Option<HashMap<String, DynamicValue>>,
+    pub private_attributes: Option<UserDataMap>,
+    pub custom: Option<UserDataMap>,
 }
 
 impl UserData {

--- a/statsig-rust/tests/exposure_sampling_key_tests.rs
+++ b/statsig-rust/tests/exposure_sampling_key_tests.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
+use indexmap::IndexMap;
 use more_asserts::{assert_gt, assert_lt};
 use serde_json::json;
 use statsig_rust::{
@@ -38,7 +39,7 @@ fn test_is_sampled_single_custom_id_only() {
 
     for i in 0..100_000u64 {
         let user_data = UserData {
-            custom_ids: Some(HashMap::from([("test".to_string(), dyn_value!(i))])),
+            custom_ids: Some(IndexMap::from([("test".to_string(), dyn_value!(i))])),
             ..Default::default()
         };
 
@@ -57,7 +58,7 @@ fn test_is_sampled_multiple_custom_ids_only() {
 
     for i in 0..100_000u64 {
         let user_data = UserData {
-            custom_ids: Some(HashMap::from([
+            custom_ids: Some(IndexMap::from([
                 ("test".to_string(), dyn_value!(i)),
                 ("test2".to_string(), dyn_value!(i.wrapping_mul(i))),
             ])),
@@ -80,7 +81,7 @@ fn test_duplicate_unit_ids() {
     for i in 0..100_000u64 {
         let user_data = UserData {
             user_id: Some(dyn_value!(i)),
-            custom_ids: Some(HashMap::from([("user_id".to_string(), dyn_value!(i))])),
+            custom_ids: Some(IndexMap::from([("user_id".to_string(), dyn_value!(i))])),
             ..Default::default()
         };
 
@@ -97,7 +98,7 @@ fn test_duplicate_unit_ids() {
 fn test_dedupe_key_is_stable_for_repeated_same_user_input() {
     let user_data = UserData {
         user_id: Some(dyn_value!("user-1")),
-        custom_ids: Some(HashMap::from([
+        custom_ids: Some(IndexMap::from([
             ("companyID".to_string(), dyn_value!("company-a")),
             ("teamID".to_string(), dyn_value!(99)),
         ])),
@@ -128,7 +129,7 @@ fn test_dedupe_key_is_stable_for_repeated_same_user_input() {
 fn test_dedupe_key_changes_when_unit_id_changes_for_experiment_id_type() {
     let mut user_data = UserData {
         user_id: Some(dyn_value!("user-1")),
-        custom_ids: Some(HashMap::from([(
+        custom_ids: Some(IndexMap::from([(
             "companyID".to_string(),
             dyn_value!("company-a"),
         )])),
@@ -170,7 +171,7 @@ fn test_dedupe_key_changes_when_custom_ids_hash_scope_changes() {
         Some("companyID"),
     );
 
-    user_data.custom_ids = Some(HashMap::from([
+    user_data.custom_ids = Some(IndexMap::from([
         ("companyID".to_string(), dyn_value!("company-a")),
         ("teamID".to_string(), dyn_value!("team-a")),
     ]));

--- a/statsig-rust/tests/statsig_user_builder_tests.rs
+++ b/statsig-rust/tests/statsig_user_builder_tests.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use statsig_rust::{dyn_value, evaluation::dynamic_string::DynamicString, StatsigUserBuilder};
 use std::collections::HashMap;
 
@@ -155,7 +156,7 @@ fn test_setting_attr_map_fields() {
 
     assert_eq!(
         user.data.custom,
-        Some(HashMap::from([(
+        Some(IndexMap::from([(
             "test_custom_again".to_string(),
             dyn_value!("a"),
         )]))
@@ -165,8 +166,9 @@ fn test_setting_attr_map_fields() {
     // assert_eq!(user.private_attributes, None);
     assert_eq!(
         user.data.private_attributes,
-        Some(HashMap::from([
-            ("test_private".to_string(), dyn_value!(2),)
-        ]))
+        Some(IndexMap::from([(
+            "test_private".to_string(),
+            dyn_value!(2),
+        )]))
     );
 }

--- a/statsig-rust/tests/statsig_user_field_accessor_tests.rs
+++ b/statsig-rust/tests/statsig_user_field_accessor_tests.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use statsig_rust::{dyn_value, StatsigUser};
 use std::collections::HashMap;
 
@@ -21,13 +22,13 @@ fn test_custom_ids_accessor() {
     user.set_custom_ids(HashMap::from([("employeeID", "num1")]));
     assert_eq!(
         user.get_custom_ids(),
-        Some(HashMap::from([("employeeID", "num1")]))
+        Some(IndexMap::from([("employeeID", "num1")]))
     );
 
     user.set_custom_ids(HashMap::from([("employeeID", 1)]));
     assert_eq!(
         user.get_custom_ids(),
-        Some(HashMap::from([("employeeID", "1")]))
+        Some(IndexMap::from([("employeeID", "1")]))
     );
 }
 
@@ -87,18 +88,18 @@ macro_rules! test_map_field_accessor {
             user.$setter_name(HashMap::from([("isAdmin", true)]));
             assert_eq!(
                 user.$getter_name(),
-                Some(&HashMap::from([("isAdmin".to_string(), dyn_value!(true))]))
+                Some(&IndexMap::from([("isAdmin".to_string(), dyn_value!(true))]))
             );
 
             // Option<HashMap<String, bool>>
             user.$setter_name(Some(HashMap::from([("isAdmin", true)])));
             assert_eq!(
                 user.$getter_name(),
-                Some(&HashMap::from([("isAdmin".to_string(), dyn_value!(true))]))
+                Some(&IndexMap::from([("isAdmin".to_string(), dyn_value!(true))]))
             );
 
             // HashMap<String, DynamicValue>
-            let multi_custom = HashMap::from([
+            let multi_custom = IndexMap::from([
                 ("isAdmin".to_string(), dyn_value!(true)),
                 ("powerLevel".to_string(), dyn_value!(10)),
             ]);

--- a/statsig-rust/tests/statsig_user_loggable_tests.rs
+++ b/statsig-rust/tests/statsig_user_loggable_tests.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use assert_json_diff::assert_json_eq;
+use indexmap::IndexMap;
 use serde_json::{json, Value};
 use statsig_rust::{
     dyn_value,
@@ -38,7 +39,7 @@ fn test_empty_user_serialization() {
 fn test_private_attributes_serialization() {
     let loggable = StatsigUserLoggable {
         data: Arc::new(UserData {
-            private_attributes: Some(HashMap::from([(
+            private_attributes: Some(IndexMap::from([(
                 "private_attribute_key".to_string(),
                 dyn_value!("a_private_attribute_value"),
             )])),
@@ -57,7 +58,7 @@ fn test_full_user_serialization() {
     let loggable = StatsigUserLoggable {
         data: Arc::new(UserData {
             user_id: Some(dyn_value!("a_user")),
-            custom_ids: Some(HashMap::from([(
+            custom_ids: Some(IndexMap::from([(
                 "custom_id".to_string(),
                 dyn_value!("a_value"),
             )])),
@@ -67,15 +68,15 @@ fn test_full_user_serialization() {
             country: Some(dyn_value!("a_country")),
             locale: Some(dyn_value!("a_locale")),
             app_version: Some(dyn_value!("a_app_version")),
-            custom: Some(HashMap::from([(
+            custom: Some(IndexMap::from([(
                 "custom_key".to_string(),
                 dyn_value!("a_custom_value"),
             )])),
-            private_attributes: Some(HashMap::from([(
+            private_attributes: Some(IndexMap::from([(
                 "private_attribute_key".to_string(),
                 dyn_value!("a_private_attribute_value"),
             )])),
-            statsig_environment: Some(HashMap::from([(
+            statsig_environment: Some(IndexMap::from([(
                 "statsig_environment_key".to_string(),
                 dyn_value!("a_statsig_environment_value"),
             )])),
@@ -109,7 +110,7 @@ fn test_full_user_serialization() {
 fn test_environment_serialization() {
     let loggable = StatsigUserLoggable {
         data: Arc::new(UserData::default()),
-        environment: Some(HashMap::from([(
+        environment: Some(IndexMap::from([(
             "tier".to_string(),
             dyn_value!("a_environment_value"),
         )])),
@@ -131,18 +132,18 @@ fn test_environment_serialization() {
 fn test_user_custom_overrides_global_custom() {
     let loggable = StatsigUserLoggable {
         data: Arc::new(UserData {
-            custom: Some(HashMap::from([(
+            custom: Some(IndexMap::from([(
                 "custom_key".to_string(),
                 dyn_value!("from_local_custom"),
             )])),
-            private_attributes: Some(HashMap::from([(
+            private_attributes: Some(IndexMap::from([(
                 "custom_key".to_string(),
                 dyn_value!("from_private_custom"),
             )])),
             ..Default::default()
         }),
         environment: None,
-        global_custom: Some(HashMap::from([(
+        global_custom: Some(IndexMap::from([(
             "custom_key".to_string(),
             dyn_value!("from_global_custom"),
         )])),
@@ -167,7 +168,7 @@ fn test_global_custom_serialization() {
     let loggable = StatsigUserLoggable {
         data: user.data,
         environment: None,
-        global_custom: Some(HashMap::from([(
+        global_custom: Some(IndexMap::from([(
             "global_custom_key".to_string(),
             dyn_value!("global_custom_value"),
         )])),

--- a/statsig-rust/tests/statsig_user_tests.rs
+++ b/statsig-rust/tests/statsig_user_tests.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use statsig_rust::{dyn_value, StatsigUser};
 use std::collections::HashMap;
 
@@ -15,7 +16,7 @@ fn test_creation_with_custom_ids() {
     )]));
     assert_eq!(
         user.data.custom_ids,
-        Some(HashMap::from([(
+        Some(IndexMap::from([(
             "companyID".to_string(),
             dyn_value!("statsig")
         )]))
@@ -53,8 +54,8 @@ fn test_changing_string_fields() {
 
 #[test]
 fn test_setting_attr_map_fields() {
-    let custom = HashMap::from([("test_custom".to_string(), dyn_value!(1))]);
-    let priv_attr = HashMap::from([("test_private".to_string(), dyn_value!(2))]);
+    let custom = IndexMap::from([("test_custom".to_string(), dyn_value!(1))]);
+    let priv_attr = IndexMap::from([("test_private".to_string(), dyn_value!(2))]);
 
     let mut user = StatsigUser::with_user_id("".to_string());
 
@@ -74,7 +75,7 @@ fn test_setting_statsig_environment() {
     )])));
     assert_eq!(
         user.get_statsig_environment(),
-        Some(HashMap::from([("test_environment", "test_value")]))
+        Some(IndexMap::from([("test_environment", "test_value")]))
     );
 
     user.set_statsig_environment(None::<HashMap<String, String>>);


### PR DESCRIPTION
## Summary

Switches UserData map fields from HashMap to an insertion-ordered IndexMap alias exported as StatsigUserDataMap.

This keeps log-event user serialization stable for repeated users, including the merged custom field path in StatsigUserLoggable, where a fresh temporary map used to be created during serialization. The change also keeps existing HashMap setter ergonomics while allowing ordered map inputs to preserve order.

## Impact

Stable user map ordering improves compressed log event payload size when the same logical user appears repeatedly in a log event request. In the same-user benchmark using Statsig::log_event with a 40-entry custom map and one 2,000-event request, gzip payload size dropped from about 154-156 KB to about 21.7 KB.

## Validation

- cargo check -p statsig-rust
- cargo test -p statsig-rust --no-run
- cargo test -p statsig-rust --test statsig_user_tests --test statsig_user_field_accessor_tests --test statsig_user_builder_tests --test statsig_user_loggable_tests --test exposure_sampling_key_tests
- cargo check --manifest-path examples/rust/mem-bench/Cargo.toml --locked
- git diff --check