### PR TITLE
memory leak reproducer in go and rust

### DIFF
--- a/statsig-go/data_store.go
+++ b/statsig-go/data_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"unsafe"
 
 	"github.com/statsig-io/statsig-go-core/internal"
 )
@@ -31,17 +32,17 @@ func NewDataStore(functions DataStoreFunctions) *DataStore {
 		store.functions.Initialize,
 		store.functions.Shutdown,
 		// Get
-		func(argPtr *byte, argLength uint64) *byte {
+		func(argPtr uintptr, argLength uint64) uintptr {
 			keyStr := internal.GoStringFromPointer(argPtr, argLength)
 			if keyStr == nil {
-				return nil
+				return 0
 			}
 
 			result := []byte(store.functions.Get(*keyStr))
-			return &result[0]
+			return uintptr(unsafe.Pointer(&result[0]))
 		},
 		// Set
-		func(argPtr *byte, argLength uint64) {
+		func(argPtr uintptr, argLength uint64) {
 			data, err := tryMarshalDataStoreSetArgs(argPtr, argLength)
 			if err != nil {
 				fmt.Println("Error marshalling DataStore 'set' args", err)
@@ -54,7 +55,7 @@ func NewDataStore(functions DataStoreFunctions) *DataStore {
 			store.functions.Set(keyStr, valueStr, time)
 		},
 		// ShouldBeUsedForQueryingUpdates
-		func(argPtr *byte, argLength uint64) bool {
+		func(argPtr uintptr, argLength uint64) bool {
 			keyStr := internal.GoStringFromPointer(argPtr, argLength)
 			if keyStr == nil {
 				return false
@@ -81,7 +82,7 @@ type dataStoreSetArgs struct {
 	Time  *uint64 `json:"time"`
 }
 
-func tryMarshalDataStoreSetArgs(inputPtr *byte, inputLength uint64) (*dataStoreSetArgs, error) {
+func tryMarshalDataStoreSetArgs(inputPtr uintptr, inputLength uint64) (*dataStoreSetArgs, error) {
 	data := internal.GoStringFromPointer(inputPtr, inputLength)
 
 	var args dataStoreSetArgs

--- a/statsig-go/internal/ffi_utils.go
+++ b/statsig-go/internal/ffi_utils.go
@@ -2,28 +2,34 @@ package internal
 
 import "unsafe"
 
-func GoStringFromPointer(inputPtr *byte, inputLength uint64) *string {
-	if inputPtr == nil {
+// GoStringFromPointer copies a Rust-owned, NUL-unaware byte buffer of the given
+// length into a Go string. inputPtr is the raw address of memory allocated by
+// the Rust FFI (not the Go heap), carried as a uintptr so the Go GC / stack
+// mover never tracks or relocates it. The uintptr->unsafe.Pointer conversion is
+// safe because the buffer is owned by Rust and stays valid until the caller
+// frees it; vet's unsafeptr warning does not apply to foreign memory.
+func GoStringFromPointer(inputPtr uintptr, inputLength uint64) *string {
+	if inputPtr == 0 {
 		return nil
 	}
 
-	s := string(unsafe.Slice(inputPtr, inputLength))
+	s := string(unsafe.Slice((*byte)(unsafe.Pointer(inputPtr)), inputLength)) //nolint:govet // foreign (Rust-owned) memory, see doc comment
 	return &s
 }
 
-func UnperformantGoStringFromPointer(inputPtr *byte) *string {
-	if inputPtr == nil {
+func UnperformantGoStringFromPointer(inputPtr uintptr) *string {
+	if inputPtr == 0 {
 		return nil
 	}
 
 	var n uintptr
 	for {
-		if *(*byte)(unsafe.Add(unsafe.Pointer(inputPtr), n)) == 0 {
+		if *(*byte)(unsafe.Pointer(inputPtr + n)) == 0 { //nolint:govet // foreign (Rust-owned) memory, see GoStringFromPointer
 			break
 		}
 		n++
 	}
 
-	s := string(unsafe.Slice(inputPtr, n))
+	s := string(unsafe.Slice((*byte)(unsafe.Pointer(inputPtr)), n)) //nolint:govet // foreign (Rust-owned) memory, see GoStringFromPointer
 	return &s
 }

--- a/statsig-go/observability_client.go
+++ b/statsig-go/observability_client.go
@@ -42,7 +42,7 @@ func NewObservabilityClient(functions ObservabilityClientFunctions) *Observabili
 	client.ref = GetFFI().observability_client_create(
 		client.functions.Init,
 		// Increment
-		func(argsPtr *byte, argsLength uint64) {
+		func(argsPtr uintptr, argsLength uint64) {
 			data, err := tryMarshalStandardArgs(argsPtr, argsLength)
 			if err != nil {
 				fmt.Println("Error marshalling observability client args", err)
@@ -52,7 +52,7 @@ func NewObservabilityClient(functions ObservabilityClientFunctions) *Observabili
 			client.functions.Increment(data.Metric, data.Value, data.Tags)
 		},
 		// Gauge
-		func(argsPtr *byte, argsLength uint64) {
+		func(argsPtr uintptr, argsLength uint64) {
 			data, err := tryMarshalStandardArgs(argsPtr, argsLength)
 			if err != nil {
 				fmt.Println("Error marshalling observability client args", err)
@@ -61,7 +61,7 @@ func NewObservabilityClient(functions ObservabilityClientFunctions) *Observabili
 			client.functions.Gauge(data.Metric, data.Value, data.Tags)
 		},
 		// Dist
-		func(argsPtr *byte, argsLength uint64) {
+		func(argsPtr uintptr, argsLength uint64) {
 			data, err := tryMarshalStandardArgs(argsPtr, argsLength)
 			if err != nil {
 				fmt.Println("Error marshalling observability client args", err)
@@ -70,7 +70,7 @@ func NewObservabilityClient(functions ObservabilityClientFunctions) *Observabili
 			client.functions.Dist(data.Metric, data.Value, data.Tags)
 		},
 		// Error
-		func(argsPtr *byte, argsLength uint64) {
+		func(argsPtr uintptr, argsLength uint64) {
 			data, err := tryMarshalErrorArgs(argsPtr, argsLength)
 			if err != nil {
 				fmt.Println("Error marshalling observability client args", err)
@@ -79,7 +79,7 @@ func NewObservabilityClient(functions ObservabilityClientFunctions) *Observabili
 			client.functions.Error(data.Tag, data.Error)
 		},
 		// ShouldEnableHighCardinalityForThisTag
-		func(argsPtr *byte, argsLength uint64) bool {
+		func(argsPtr uintptr, argsLength uint64) bool {
 			tag := internal.GoStringFromPointer(argsPtr, argsLength)
 			return client.functions.ShouldEnableHighCardinalityForThisTag(*tag)
 		},
@@ -96,7 +96,7 @@ func (c *ObservabilityClient) INTERNAL_testObservabilityClient(action string, me
 	GetFFI().__internal__test_observability_client(c.ref, action, metricName, value, tags)
 }
 
-func tryMarshalStandardArgs(inputPtr *byte, inputLength uint64) (*obsClientArgs, error) {
+func tryMarshalStandardArgs(inputPtr uintptr, inputLength uint64) (*obsClientArgs, error) {
 	data := internal.GoStringFromPointer(inputPtr, inputLength)
 
 	var args obsClientArgs
@@ -109,7 +109,7 @@ func tryMarshalStandardArgs(inputPtr *byte, inputLength uint64) (*obsClientArgs,
 	return &args, nil
 }
 
-func tryMarshalErrorArgs(inputPtr *byte, inputLength uint64) (*obsClientErrorArgs, error) {
+func tryMarshalErrorArgs(inputPtr uintptr, inputLength uint64) (*obsClientErrorArgs, error) {
 	data := internal.GoStringFromPointer(inputPtr, inputLength)
 
 	var args obsClientErrorArgs

--- a/statsig-go/persistent_storage.go
+++ b/statsig-go/persistent_storage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"unsafe"
 
 	"github.com/statsig-io/statsig-go-core/internal"
 )
@@ -55,28 +56,28 @@ func NewPersistentStorage(functions PersistentStorageFunctions) *PersistentStora
 	storage.ref = GetFFI().persistent_storage_create(
 		"go",
 		// Load
-		func(argsPtr *byte, argsLength uint64) *byte {
+		func(argsPtr uintptr, argsLength uint64) uintptr {
 			keyStr := internal.GoStringFromPointer(argsPtr, argsLength)
 			if keyStr == nil {
-				return nil
+				return 0
 			}
 
 			result := storage.functions.Load(*keyStr)
 
 			if result == nil {
-				return nil
+				return 0
 			}
 
 			json, err := json.Marshal(*result)
 			if err != nil {
 				fmt.Println("Error marshalling user persisted values", err)
-				return nil
+				return 0
 			}
 
-			return &json[0]
+			return uintptr(unsafe.Pointer(&json[0]))
 		},
 		// Save
-		func(argsPtr *byte, argsLength uint64) {
+		func(argsPtr uintptr, argsLength uint64) {
 			data, err := tryMarshalPersistentStorageArgs(argsPtr, argsLength)
 			if err != nil {
 				fmt.Println("Error marshalling persistent storage args", err)
@@ -91,7 +92,7 @@ func NewPersistentStorage(functions PersistentStorageFunctions) *PersistentStora
 			storage.functions.Save(data.Key, data.ConfigName, *data.Data)
 		},
 		// Delete
-		func(argsPtr *byte, argsLength uint64) {
+		func(argsPtr uintptr, argsLength uint64) {
 			data, err := tryMarshalPersistentStorageArgs(argsPtr, argsLength)
 			if err != nil {
 				fmt.Println("Error marshalling persistent storage args", err)
@@ -112,7 +113,7 @@ func (c *PersistentStorage) INTERNAL_testPersistentStorage(action string, key st
 	return GetFFI().__internal__test_persistent_storage(c.ref, action, key, configName, data)
 }
 
-func tryMarshalPersistentStorageArgs(inputPtr *byte, inputLength uint64) (*persistentStorageArgs, error) {
+func tryMarshalPersistentStorageArgs(inputPtr uintptr, inputLength uint64) (*persistentStorageArgs, error) {
 	data := internal.GoStringFromPointer(inputPtr, inputLength)
 
 	var args persistentStorageArgs

--- a/statsig-go/statsig.go
+++ b/statsig-go/statsig.go
@@ -103,7 +103,7 @@ func (s *Statsig) GetFeatureGateWithOptions(user *StatsigUser, gateName string, 
 		return gate
 	}
 
-	gateJson := UseRustString(func() (*byte, uint64) {
+	gateJson := UseRustString(func() (uintptr, uint64) {
 		len := uint64(0)
 		ptr := GetFFI().statsig_get_raw_feature_gate(s.ref.Load(), user.ref, gateName, optionsJson, &len)
 		return ptr, len
@@ -131,7 +131,7 @@ func (s *Statsig) GetDynamicConfigWithOptions(user *StatsigUser, configName stri
 		return config
 	}
 
-	configJson := UseRustString(func() (*byte, uint64) {
+	configJson := UseRustString(func() (uintptr, uint64) {
 		len := uint64(0)
 		ptr := GetFFI().statsig_get_raw_dynamic_config(s.ref.Load(), user.ref, configName, optionsJson, &len)
 		return ptr, len
@@ -163,7 +163,7 @@ func (s *Statsig) GetExperimentWithOptions(user *StatsigUser, experimentName str
 		return experiment
 	}
 
-	experimentJson := UseRustString(func() (*byte, uint64) {
+	experimentJson := UseRustString(func() (uintptr, uint64) {
 		len := uint64(0)
 		ptr := GetFFI().statsig_get_raw_experiment(s.ref.Load(), user.ref, experimentName, optionsJson, &len)
 		return ptr, len
@@ -197,7 +197,7 @@ func (s *Statsig) GetLayerWithOptions(user *StatsigUser, layerName string, optio
 		return layer
 	}
 
-	layerJson := UseRustString(func() (*byte, uint64) {
+	layerJson := UseRustString(func() (uintptr, uint64) {
 		len := uint64(0)
 		ptr := GetFFI().statsig_get_raw_layer(s.ref.Load(), user.ref, layerName, optionsJson, &len)
 		return ptr, len
@@ -238,7 +238,7 @@ func (s *Statsig) GetParameterStoreWithOptions(
 		return store
 	}
 
-	storeJson := UseRustString(func() (*byte, uint64) {
+	storeJson := UseRustString(func() (uintptr, uint64) {
 		length := uint64(0)
 		ptr := GetFFI().statsig_get_parameter_store_with_options(
 			s.ref.Load(),
@@ -278,7 +278,7 @@ func (s *Statsig) GetClientInitResponseWithOptions(user *StatsigUser, options *C
 		return nil
 	}
 
-	return UseRustString(func() (*byte, uint64) {
+	return UseRustString(func() (uintptr, uint64) {
 		len := uint64(0)
 		ptr := GetFFI().statsig_get_client_init_response_with_inout_len(s.ref.Load(), user.ref, optionsJson, &len)
 		return ptr, len

--- a/statsig-go/statsig_ffi.go
+++ b/statsig-go/statsig_ffi.go
@@ -31,24 +31,24 @@ type StatsigFFI struct {
 	statsig_flush_events_blocking                   func(uint64)
 	statsig_log_event                               func(uint64, uint64, string)
 	statsig_identify                                func(uint64, uint64)
-	statsig_get_client_init_response_with_inout_len func(uint64, uint64, string, *uint64) *byte
+	statsig_get_client_init_response_with_inout_len func(uint64, uint64, string, *uint64) uintptr
 
 	// Gates
 	statsig_check_gate                 func(uint64, uint64, string, string) bool
 	statsig_check_gate_performance     func(uint64, uint64, string, uint, string, uint) bool
-	statsig_get_raw_feature_gate       func(uint64, uint64, string, string, *uint64) *byte
+	statsig_get_raw_feature_gate       func(uint64, uint64, string, string, *uint64) uintptr
 	statsig_manually_log_gate_exposure func(uint64, uint64, string)
 
 	// Dynamic Configs
-	statsig_get_raw_dynamic_config               func(uint64, uint64, string, string, *uint64) *byte
+	statsig_get_raw_dynamic_config               func(uint64, uint64, string, string, *uint64) uintptr
 	statsig_manually_log_dynamic_config_exposure func(uint64, uint64, string)
 
 	// Experiments
-	statsig_get_raw_experiment               func(uint64, uint64, string, string, *uint64) *byte
+	statsig_get_raw_experiment               func(uint64, uint64, string, string, *uint64) uintptr
 	statsig_manually_log_experiment_exposure func(uint64, uint64, string)
 
 	// Layers
-	statsig_get_raw_layer                         func(uint64, uint64, string, string, *uint64) *byte
+	statsig_get_raw_layer                         func(uint64, uint64, string, string, *uint64) uintptr
 	log_layer_param_exposure_from_raw             func(uint64, string, string)
 	statsig_manually_log_layer_parameter_exposure func(uint64, uint64, string, string)
 
@@ -68,9 +68,9 @@ type StatsigFFI struct {
 	data_store_create func(
 		init_fn func(),
 		shutdown_fn func(),
-		get_fn func(argPtr *byte, argLength uint64) *byte,
-		set_fn func(argPtr *byte, argLength uint64),
-		support_polling_updates_for_fn func(argPtr *byte, argLength uint64) bool,
+		get_fn func(argPtr uintptr, argLength uint64) uintptr,
+		set_fn func(argPtr uintptr, argLength uint64),
+		support_polling_updates_for_fn func(argPtr uintptr, argLength uint64) bool,
 	) uint64
 	data_store_release          func(uint64)
 	__internal__test_data_store func(uint64, string, string) string
@@ -78,11 +78,11 @@ type StatsigFFI struct {
 	// Observability Client
 	observability_client_create func(
 		init_fn func(),
-		increment_fn func(argsPtr *byte, argsLength uint64),
-		gauge_fn func(argsPtr *byte, argsLength uint64),
-		dist_fn func(argsPtr *byte, argsLength uint64),
-		error_fn func(argsPtr *byte, argsLength uint64),
-		should_enable_high_cardinality_for_this_tag_fn func(argsPtr *byte, argsLength uint64) bool,
+		increment_fn func(argsPtr uintptr, argsLength uint64),
+		gauge_fn func(argsPtr uintptr, argsLength uint64),
+		dist_fn func(argsPtr uintptr, argsLength uint64),
+		error_fn func(argsPtr uintptr, argsLength uint64),
+		should_enable_high_cardinality_for_this_tag_fn func(argsPtr uintptr, argsLength uint64) bool,
 	) uint64
 	observability_client_release          func(uint64)
 	__internal__test_observability_client func(
@@ -96,9 +96,9 @@ type StatsigFFI struct {
 	// Persistent Storage
 	persistent_storage_create func(
 		bindingsLanguage string,
-		load_fn func(argsPtr *byte, argsLength uint64) *byte,
-		save_fn func(argsPtr *byte, argsLength uint64),
-		delete_fn func(argsPtr *byte, argsLength uint64),
+		load_fn func(argsPtr uintptr, argsLength uint64) uintptr,
+		save_fn func(argsPtr uintptr, argsLength uint64),
+		delete_fn func(argsPtr uintptr, argsLength uint64),
 	) uint64
 	persistent_storage_release          func(uint64)
 	__internal__test_persistent_storage func(uint64, string, string, string, string) string
@@ -107,16 +107,16 @@ type StatsigFFI struct {
 	statsig_metadata_update_values func(string, string, string, string)
 
 	// Utility
-	free_string func(*byte)
+	free_string func(uintptr)
 
 	// Parameter Store
-	statsig_get_parameter_store_with_options             func(uint64, string, string, *uint64) *byte
-	statsig_get_string_parameter_from_parameter_store    func(uint64, uint64, string, string, string, string, *uint64) *byte
+	statsig_get_parameter_store_with_options             func(uint64, string, string, *uint64) uintptr
+	statsig_get_string_parameter_from_parameter_store    func(uint64, uint64, string, string, string, string, *uint64) uintptr
 	statsig_get_bool_parameter_from_parameter_store      func(uint64, uint64, string, string, int32, string) bool
 	statsig_get_float64_parameter_from_parameter_store   func(uint64, uint64, string, string, float64, string) float64
 	statsig_get_int_parameter_from_parameter_store       func(uint64, uint64, string, string, int64, string) int64
-	statsig_get_object_parameter_from_parameter_store    func(uint64, uint64, string, string, string, string, *uint64) *byte
-	statsig_get_array_parameter_from_parameter_store     func(uint64, uint64, string, string, string, string, *uint64) *byte
+	statsig_get_object_parameter_from_parameter_store    func(uint64, uint64, string, string, string, string, *uint64) uintptr
+	statsig_get_array_parameter_from_parameter_store     func(uint64, uint64, string, string, string, string, *uint64) uintptr
 }
 
 var (
@@ -222,9 +222,9 @@ func GetFFI() *StatsigFFI {
 	return instance
 }
 
-func UseRustString(handler func() (*byte, uint64)) *string {
+func UseRustString(handler func() (uintptr, uint64)) *string {
 	ptr, length := handler()
-	if ptr == nil {
+	if ptr == 0 {
 		return nil
 	}
 

--- a/statsig-go/statsig_types.go
+++ b/statsig-go/statsig_types.go
@@ -162,7 +162,7 @@ type ParameterStore struct {
 
 func (p *ParameterStore) GetString(key string, fallback string) string {
 	return parameterStoreValue(p, fallback, func(optionsJson string) (string, bool) {
-		result := UseRustString(func() (*byte, uint64) {
+		result := UseRustString(func() (uintptr, uint64) {
 			length := uint64(0)
 			ptr := GetFFI().statsig_get_string_parameter_from_parameter_store(
 				p.statsigRef,
@@ -228,7 +228,7 @@ func (p *ParameterStore) GetMap(key string, fallback map[string]any) map[string]
 			return fallback, false
 		}
 
-		result := UseRustString(func() (*byte, uint64) {
+		result := UseRustString(func() (uintptr, uint64) {
 			length := uint64(0)
 			ptr := GetFFI().statsig_get_object_parameter_from_parameter_store(
 				p.statsigRef,
@@ -260,7 +260,7 @@ func (p *ParameterStore) GetSlice(key string, fallback []any) []any {
 			return fallback, false
 		}
 
-		result := UseRustString(func() (*byte, uint64) {
+		result := UseRustString(func() (uintptr, uint64) {
 			length := uint64(0)
 			ptr := GetFFI().statsig_get_array_parameter_from_parameter_store(
 				p.statsigRef,

--- a/statsig-go/test/memory_leak_per_request_users_test.go
+++ b/statsig-go/test/memory_leak_per_request_users_test.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestMemoryLeakPerRequestUsers simulates a server-side usage pattern where
+// each incoming request carries a different end-user identity (e.g. a distinct
+// accountUuid / sessionId / visitorId). The existing TestMemoryLeak allocates
+// per-iteration users but discards them without querying — so any SDK state
+// that's keyed on `userID` never gets exercised. This test passes the unique
+// per-iteration user directly into GetFeatureGate / GetDynamicConfig /
+// GetExperiment / GetLayer / GetClientInitResponse, which is what a real
+// high-cardinality server workload looks like.
+//
+// Shares helpers (createUser, triggerGC, getRssBytes, humanizeBytes,
+// loadLargeDcsData, SetupTestWithDcsData) with memory_leak_test.go.
+func TestMemoryLeakPerRequestUsers(t *testing.T) {
+	resData := loadLargeDcsData(t)
+	statsig, _, _ := SetupTestWithDcsData(t, resData)
+
+	time.Sleep(1 * time.Second)
+
+	// Warmup: let background threads / initial allocations settle.
+	for i := range 10 {
+		u := createUser(t, i)
+		_ = statsig.GetFeatureGate(u, "test_public")
+		_ = statsig.GetDynamicConfig(u, "test_empty_array")
+		_ = statsig.GetExperiment(u, "exp_with_obj_and_array")
+		_ = statsig.GetLayer(u, "layer_with_many_params")
+		_ = statsig.GetClientInitResponse(u)
+	}
+
+	time.Sleep(1 * time.Second)
+	triggerGC()
+
+	initialRss := getRssBytes(t)
+	fmt.Println("Initial RSS: ", humanizeBytes(initialRss))
+
+	// Hot loop: each iteration uses a fresh, unique userID. This is what
+	// stresses any SDK state keyed on userID (exposure queue entries cloning
+	// user objects, per-user evaluation caches, etc.).
+	const iterations = 10000
+	for i := range iterations {
+		u := createUser(t, i)
+		_ = statsig.GetFeatureGate(u, "test_public")
+		_ = statsig.GetDynamicConfig(u, "test_empty_array")
+		_ = statsig.GetExperiment(u, "exp_with_obj_and_array")
+		_ = statsig.GetLayer(u, "layer_with_many_params")
+		_ = statsig.GetClientInitResponse(u)
+	}
+
+	time.Sleep(1 * time.Second)
+	triggerGC()
+
+	finalRss := getRssBytes(t)
+	fmt.Println("Final RSS: ", humanizeBytes(finalRss))
+
+	percentChange := float64(finalRss-initialRss) / float64(initialRss) * 100
+	delta := finalRss - initialRss
+
+	if percentChange > 50 {
+		t.Errorf("Memory leak detected with per-request users: %s (%.2f%%)", humanizeBytes(delta), percentChange)
+	} else {
+		fmt.Printf("Memory change within acceptable range: %s (%.2f%%)", humanizeBytes(delta), percentChange)
+	}
+}

--- a/statsig-go/test/memory_leak_per_request_users_test.go
+++ b/statsig-go/test/memory_leak_per_request_users_test.go
@@ -19,12 +19,18 @@ import (
 // loadLargeDcsData, SetupTestWithDcsData) with memory_leak_test.go.
 func TestMemoryLeakPerRequestUsers(t *testing.T) {
 	resData := loadLargeDcsData(t)
-	statsig, _, _ := SetupTestWithDcsData(t, resData)
+	statsig, scrapi, _ := SetupTestWithDcsData(t, resData)
+
+	// Stop the mock from retaining every request body and every parsed
+	// log_event payload. Without this, the bulk of measured RSS growth in
+	// this test is the harness storing user payloads (especially the
+	// ~100KB dummyString in createUser), not the SDK's own state.
+	scrapi.DisableRecording()
 
 	time.Sleep(1 * time.Second)
 
 	// Warmup: let background threads / initial allocations settle.
-	for i := range 10 {
+	for i := range 10000 {
 		u := createUser(t, i)
 		_ = statsig.GetFeatureGate(u, "test_public")
 		_ = statsig.GetDynamicConfig(u, "test_empty_array")
@@ -37,13 +43,18 @@ func TestMemoryLeakPerRequestUsers(t *testing.T) {
 	triggerGC()
 
 	initialRss := getRssBytes(t)
-	fmt.Println("Initial RSS: ", humanizeBytes(initialRss))
+	fmt.Println("Initial RSS after warmup: ", humanizeBytes(initialRss))
 
 	// Hot loop: each iteration uses a fresh, unique userID. This is what
 	// stresses any SDK state keyed on userID (exposure queue entries cloning
 	// user objects, per-user evaluation caches, etc.).
-	const iterations = 10000
+	const iterations = 1280001
 	for i := range iterations {
+		if i == 10000 || i == 20000 || i == 40000 || i == 80000 || i == 160000 || i == 320000 || i == 640000 || i == 1280000 {
+			triggerGC()
+			rss := getRssBytes(t)
+			fmt.Println("RSS at iteration ", i, ": ", humanizeBytes(rss))
+		}
 		u := createUser(t, i)
 		_ = statsig.GetFeatureGate(u, "test_public")
 		_ = statsig.GetDynamicConfig(u, "test_empty_array")

--- a/statsig-go/test/mock_scrapi.go
+++ b/statsig-go/test/mock_scrapi.go
@@ -43,6 +43,30 @@ type MockScrapi struct {
 	stubs    map[key][]StubResponse // FIFO per key
 	fallback *StubResponse
 	events   []map[string]any
+
+	// When true, handle() does not retain request bodies or parsed events.
+	// Stubs and the response path still work. Use this for high-volume
+	// tests where the harness's per-request retention dominates any SDK-
+	// side memory measurement (e.g. memory leak / load tests).
+	recordingDisabled bool
+}
+
+// DisableRecording stops the mock from storing request bodies and parsed
+// log_event payloads, and drops anything already retained. Stubs and the
+// response path are unaffected.
+//
+// Why: every recorded request is a deep copy of its body and headers, and
+// every parsed log_event payload is fully unmarshalled into a Go map.
+// Across tens of thousands of iterations with non-trivial user payloads,
+// that retention is several orders of magnitude larger than the SDK's
+// own steady-state memory and makes memory leak tests measure the mock,
+// not the SDK.
+func (m *MockScrapi) DisableRecording() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recordingDisabled = true
+	m.requests = nil
+	m.events = nil
 }
 
 // New creates a running mock server.
@@ -169,23 +193,26 @@ func (m *MockScrapi) handle(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("Body:", string(body))
 	}
 
-	if strings.Contains(r.URL.Path, "log_event") {
-		m.tryAddEvents(body)
-	}
+	m.mu.Lock()
+	recordingDisabled := m.recordingDisabled
+	m.mu.Unlock()
 
-	// record
-	rec := RecordedRequest{
-		Method:   r.Method,
-		Path:     r.URL.Path,
-		RawQuery: r.URL.RawQuery,
-		Header:   cloneHeader(r.Header),
-		Body:     append([]byte(nil), body...),
+	if !recordingDisabled && strings.Contains(r.URL.Path, "log_event") {
+		m.tryAddEvents(body)
 	}
 
 	var resp *StubResponse
 
 	m.mu.Lock()
-	m.requests = append(m.requests, rec)
+	if !recordingDisabled {
+		m.requests = append(m.requests, RecordedRequest{
+			Method:   r.Method,
+			Path:     r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+			Header:   cloneHeader(r.Header),
+			Body:     append([]byte(nil), body...),
+		})
+	}
 
 	k := key{method: r.Method, path: r.URL.Path}
 	queue := m.stubs[k]

--- a/statsig-rust/tests/memory_leak_per_request_users_tests.rs
+++ b/statsig-rust/tests/memory_leak_per_request_users_tests.rs
@@ -1,0 +1,119 @@
+mod utils;
+
+use crate::utils::mock_scrapi::StubData;
+use crate::utils::mock_specs_adapter::MockSpecsAdapter;
+use statsig_rust::{Statsig, StatsigOptions, StatsigUser};
+use std::sync::Arc;
+use std::time::Duration;
+use utils::mock_scrapi::{Endpoint, EndpointStub, Method, MockScrapi};
+
+/// Returns resident set size in bytes by reading /proc/self/statm.
+/// Linux only; the test is `#[cfg(target_os = "linux")]` below.
+#[cfg(target_os = "linux")]
+fn get_rss_bytes() -> u64 {
+    let statm = std::fs::read_to_string("/proc/self/statm").expect("read /proc/self/statm");
+    let resident_pages: u64 = statm
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .expect("parse resident pages");
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+    resident_pages * page_size
+}
+
+#[cfg(target_os = "linux")]
+fn humanize(bytes: i64) -> String {
+    let abs = bytes.unsigned_abs() as f64;
+    if abs < 1024.0 {
+        format!("{bytes} B")
+    } else if abs < 1024.0 * 1024.0 {
+        format!("{:.2} KB", bytes as f64 / 1024.0)
+    } else if abs < 1024.0 * 1024.0 * 1024.0 {
+        format!("{:.2} MB", bytes as f64 / (1024.0 * 1024.0))
+    } else {
+        format!("{:.2} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
+async fn setup() -> (Arc<Statsig>, MockScrapi) {
+    let mock_scrapi = MockScrapi::new().await;
+    mock_scrapi
+        .stub(EndpointStub {
+            method: Method::POST,
+            response: StubData::String("{}".to_string()),
+            status: 200,
+            ..EndpointStub::with_endpoint(Endpoint::LogEvent)
+        })
+        .await;
+
+    let statsig = Statsig::new(
+        "secret-key",
+        Some(Arc::new(StatsigOptions {
+            specs_adapter: Some(Arc::new(MockSpecsAdapter::with_data(
+                "tests/data/eval_proj_dcs.json",
+            ))),
+            log_event_url: Some(mock_scrapi.url_for_endpoint(Endpoint::LogEvent)),
+            environment: Some("development".to_string()),
+            disable_country_lookup: Some(true),
+            ..StatsigOptions::new()
+        })),
+    );
+    statsig.initialize().await.unwrap();
+    (Arc::new(statsig), mock_scrapi)
+}
+
+/// Repro: server-side workload where each request carries a distinct userID.
+///
+/// The existing tests in other bindings (Go's TestMemoryLeak, C++'s
+/// memory_safety_test) either reuse a single fixed user or construct per-iter
+/// users but discard them without using them in evaluations. This test
+/// simulates the realistic server pattern: every iteration builds a fresh
+/// StatsigUser with a unique user_id and passes it to check_gate /
+/// get_dynamic_config / get_experiment / get_layer / get_client_init_response.
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread")]
+async fn per_request_users_memory_leak() {
+    let (statsig, _scrapi) = setup().await;
+
+    // Warmup
+    for i in 0..10 {
+        let u = StatsigUser::with_user_id(format!("warmup_user_{i}"));
+        let _ = statsig.check_gate(&u, "test_public");
+        let _ = statsig.get_dynamic_config(&u, "test_empty_array");
+        let _ = statsig.get_experiment(&u, "exp_with_obj_and_array");
+        let _ = statsig.get_layer(&u, "layer_with_many_params");
+        let _ = statsig.get_client_init_response(&u);
+    }
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let initial_rss = get_rss_bytes() as i64;
+    println!("Initial RSS: {}", humanize(initial_rss));
+
+    const ITERATIONS: usize = 10_000;
+    for i in 0..ITERATIONS {
+        let u = StatsigUser::with_user_id(format!("user_{i}"));
+        let _ = statsig.check_gate(&u, "test_public");
+        let _ = statsig.get_dynamic_config(&u, "test_empty_array");
+        let _ = statsig.get_experiment(&u, "exp_with_obj_and_array");
+        let _ = statsig.get_layer(&u, "layer_with_many_params");
+        let _ = statsig.get_client_init_response(&u);
+        // `u` drops here; Rust deterministically releases its owned data.
+    }
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let final_rss = get_rss_bytes() as i64;
+    println!("Final RSS:   {}", humanize(final_rss));
+
+    let delta = final_rss - initial_rss;
+    let pct = (delta as f64) / (initial_rss as f64) * 100.0;
+    println!("Delta:       {} ({:.2}%)", humanize(delta), pct);
+
+    assert!(
+        pct < 50.0,
+        "Memory leak with per-request users: {} ({:.2}%)",
+        humanize(delta),
+        pct
+    );
+}


### PR DESCRIPTION
We have seen significant, permanent growth of memory usage when rolling out statsig in our test instances and especially controlled production deployments. **This is currently blocking most uses of Statsig at DeepL.**

With the help of Claude, we have created reproducers in go and rust. More details in follow-up messages.