### PR TITLE
[codex] Pin GitHub Actions workflow references

### DIFF
--- a/.github/_legacy_workflows/cut-release.yml
+++ b/.github/_legacy_workflows/cut-release.yml
@@ -28,21 +28,21 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/_legacy_workflows/statsig-ffi.yml
+++ b/.github/_legacy_workflows/statsig-ffi.yml
@@ -39,8 +39,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
@@ -114,8 +114,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 

--- a/.github/_legacy_workflows/statsig-java-publish.yml
+++ b/.github/_legacy_workflows/statsig-java-publish.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get Release Info
         id: get_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |
             const tag = '${{ github.event.inputs.release_tag }}';
@@ -121,7 +121,7 @@ jobs:
           done
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
         with:
           java-version: '11'  # or '8' if using Java 8
           distribution: "adopt"

--- a/.github/_legacy_workflows/statsig-napi-publish.yml
+++ b/.github/_legacy_workflows/statsig-napi-publish.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get Workflow Run Info
         uses: ./.github/actions/verify-workflow-run-successful
@@ -35,7 +35,7 @@ jobs:
           git checkout ${{ github.event.inputs.release_commit_sha }}
           git submodule update --init --recursive
           
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 

--- a/.github/_legacy_workflows/statsig-napi.yml
+++ b/.github/_legacy_workflows/statsig-napi.yml
@@ -76,16 +76,16 @@ jobs:
     runs-on: ${{ matrix.config.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build Statsig Napi
         if: ${{ github.ref_name == 'main' || matrix.config.always_build || github.event_name == 'release' }}
@@ -123,7 +123,7 @@ jobs:
       - build
     steps:
       - name: Trigger NPM Publish
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           script: |
             github.rest.actions.createWorkflowDispatch({

--- a/.github/_legacy_workflows/statsig-python.yml
+++ b/.github/_legacy_workflows/statsig-python.yml
@@ -54,13 +54,13 @@ jobs:
       SHOULD_BUILD: ${{ github.ref_name == 'main' || matrix.config.always_build || github.event_name == 'release' }}
   
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install CLI Dependencies
         run: cd cli && pnpm install
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload wheels
         if: ${{ env.SHOULD_BUILD == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-${{ matrix.config.distro }}-${{ matrix.config.arch }}
           if-no-files-found: error
@@ -102,17 +102,17 @@ jobs:
             target: aarch64
           
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.x
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@423a6347767a8b16e65c2a7a7042e4a921528da8 # v1
         with:
           working-directory: statsig-pyo3
           target: ${{ matrix.platform.target }}
@@ -120,7 +120,7 @@ jobs:
           sccache: 'true'
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           if-no-files-found: error
@@ -137,14 +137,14 @@ jobs:
           - runner: windows-latest
             target: x86
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
       
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@423a6347767a8b16e65c2a7a7042e4a921528da8 # v1
         with:
           working-directory: statsig-pyo3
           target: ${{ matrix.platform.target }}
@@ -152,7 +152,7 @@ jobs:
           sccache: 'true'
      
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           if-no-files-found: error
@@ -161,17 +161,17 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@423a6347767a8b16e65c2a7a7042e4a921528da8 # v1
         with:
           working-directory: statsig-pyo3
           command: sdist
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-sdist
           if-no-files-found: error
@@ -187,15 +187,15 @@ jobs:
       contents: write
       attestations: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@92c65d2898f1f53cfdc910b962cecff86e7f8fcc # v1
         with:
           subject-path: 'wheels-*/*'
       
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@423a6347767a8b16e65c2a7a7042e4a921528da8 # v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.STATSIG_PYPI_PROD_TOKEN }}
           MATURIN_REPOSITORY: pypi

--- a/.github/actions/build-ffi-linux/action.yml
+++ b/.github/actions/build-ffi-linux/action.yml
@@ -38,14 +38,14 @@ runs:
         echo "DockerHub Username: ${{ inputs.dockerhub_username }}"
 
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
     - name: Install CLI Dependencies
       shell: bash
       run: cd cli && pnpm install
 
     - name: "Login to Docker Hub"
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
@@ -77,15 +77,15 @@ runs:
 
     - name: "[Build] Setup QEMU"
       if: env.NEEDS_BUILD == 'true'
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: "[Build] Setup Docker Build Requirements"
       if: env.NEEDS_BUILD == 'true'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: "[Build] Build Docker Image"
       if: env.NEEDS_BUILD == 'true'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         platforms: ${{ inputs.platform }}
         file: tools/docker/Dockerfile.${{ inputs.target }}

--- a/.github/actions/build-ffi-mac-and-windows/action.yml
+++ b/.github/actions/build-ffi-mac-and-windows/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "Target: ${{ inputs.target }}"
 
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
     - name: Install Rust Targets
       shell: bash

--- a/.github/actions/build-napi/action.yml
+++ b/.github/actions/build-napi/action.yml
@@ -31,12 +31,12 @@ runs:
         echo "Target: ${{ inputs.target }}"
 
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
       with:
         repo-token: ${{ inputs.gh_token }}
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 20
         architecture: ${{ inputs.node_arch || '' }}
@@ -46,7 +46,7 @@ runs:
       run: cd cli && pnpm install
 
     - name: Install Rust Tools
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       with:
         toolchain: stable
         targets: ${{ inputs.target }}
@@ -58,7 +58,7 @@ runs:
 
     - name: "[Linux-Musl] Add Zig Compiler"
       if: ${{ contains(inputs.target, 'musl') }}
-      uses: goto-bus-stop/setup-zig@v2
+      uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2
       with:
         version: 0.13.0
 

--- a/.github/actions/build-server-core-docker-image/action.yml
+++ b/.github/actions/build-server-core-docker-image/action.yml
@@ -31,7 +31,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Login to Docker Hub'
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}
@@ -63,15 +63,15 @@ runs:
 
     - name: '[Build] Setup QEMU'
       if: env.NEEDS_BUILD == 'true'
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: '[Build] Setup Docker Build Requirements'
       if: env.NEEDS_BUILD == 'true'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: '[Build] Build Docker Image'
       if: env.NEEDS_BUILD == 'true'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         platforms: ${{ inputs.platform }}
         file: ${{ inputs.dockerfile_path }}

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -4,7 +4,7 @@ description: 'Common setup for the build'
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
       name: Install PNPM
       with:
         version: 7.32.4

--- a/.github/actions/verify-workflow-run-successful/action.yml
+++ b/.github/actions/verify-workflow-run-successful/action.yml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: Get Workflow Run Info
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const run_id = '${{ inputs.workflow_run_id }}';

--- a/.github/workflows/LRS.yml
+++ b/.github/workflows/LRS.yml
@@ -47,7 +47,7 @@ jobs:
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
       
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     outputs:
       build_matrix: ${{ steps.plan.outputs.build_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Make Plan
         id: plan
         run: python3 .github/build_plan.py
@@ -102,7 +102,7 @@ jobs:
           echo "Verifying Git installation..."
           & "C:\PortableGit\bin\git.exe" --version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -119,7 +119,7 @@ jobs:
 
       - uses: ./.github/actions/common-setup
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.target }}-${{ matrix.package }}
 
@@ -246,10 +246,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/common-setup
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: centos7-x86_64-unknown-linux-gnu-node
           path: artifacts
@@ -277,10 +277,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/common-setup
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: centos7-x86_64-unknown-linux-gnu-python
           path: artifacts
@@ -323,7 +323,7 @@ jobs:
           - cpp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 

--- a/.github/workflows/cut_release_candidate.yml
+++ b/.github/workflows/cut_release_candidate.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 

--- a/.github/workflows/cut_release_candidate_manual.yml
+++ b/.github/workflows/cut_release_candidate_manual.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 

--- a/.github/workflows/kong_task.yml
+++ b/.github/workflows/kong_task.yml
@@ -37,12 +37,12 @@ jobs:
           npm run kong -- setup ${{ inputs.sdk }} -v
           npm run kong -- bridge_hash ${{ inputs.sdk }} -v
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Check if Docker Image Exists
         id: check_image
@@ -104,7 +104,7 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -141,7 +141,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
@@ -201,11 +201,11 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@8251c48667b97e88a0a24ec512f5b72a039fcea7 # v1
         with:
           otp-version: '27'
           elixir-version: '1.18'

--- a/.github/workflows/nightly-beta.yml
+++ b/.github/workflows/nightly-beta.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 

--- a/.github/workflows/nightly-rc.yml
+++ b/.github/workflows/nightly-rc.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           submodules: recursive
       
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
   

--- a/.github/workflows/package_verification.yml
+++ b/.github/workflows/package_verification.yml
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
@@ -141,9 +141,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
@@ -178,7 +178,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Verification
         working-directory: examples/python/verify-package
@@ -212,9 +212,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
         with:
           php-version: 7.4
           extensions: ffi
@@ -256,9 +256,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -48,10 +48,10 @@ jobs:
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
-      - uses: statsig-io/statsig-publish-sdk-action@main
+      - uses: statsig-io/statsig-publish-sdk-action@c0740fb8a2d4813522cc09bb8c4e826bb78ce6ab # main
         with:
           kong-private-key: ${{ secrets.KONG_GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/statsig-rust-publish.yml
+++ b/.github/workflows/statsig-rust-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 

--- a/.github/workflows/statsig-tests.yml
+++ b/.github/workflows/statsig-tests.yml
@@ -28,15 +28,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 7.32.4
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           key: ${{ matrix.lang }}
 
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/common-setup
 
       - name: Perf Report


### PR DESCRIPTION
Pin floating external GitHub Actions workflow refs to immutable SHAs.

Why are we doing this? Please see the rationale doc: https://docs.google.com/document/d/1qOURCNx2zszQ0uWx7Fj5ERu4jpiYjxLVWBWgKa2wTsA/edit?tab=t.0

Did this break you? Please roll back and let hintz@ know
