### PR TITLE
[statsig-go] add opt-in for nil userid json omission

### DIFF
--- a/statsig-go/statsig.go
+++ b/statsig-go/statsig.go
@@ -17,7 +17,8 @@ type EventPayload struct {
 }
 
 type Statsig struct {
-	ref atomic.Uint64
+	ref            atomic.Uint64
+	allowNilUserID bool
 }
 
 func NewStatsig(sdkKey string) (*Statsig, error) {
@@ -42,7 +43,7 @@ func NewStatsigWithOptions(sdkKey string, opts *StatsigOptions) (*Statsig, error
 		return nil, fmt.Errorf("error creating Statsig instance")
 	}
 
-	s := &Statsig{ref: atomic.Uint64{}}
+	s := &Statsig{ref: atomic.Uint64{}, allowNilUserID: opts.allowNilUserID}
 	s.ref.Store(ref)
 
 	runtime.SetFinalizer(s, func(obj *Statsig) {
@@ -50,6 +51,18 @@ func NewStatsigWithOptions(sdkKey string, opts *StatsigOptions) (*Statsig, error
 	})
 
 	return s, nil
+}
+
+func (s *Statsig) NewUserBuilderWithUserID(userID string) *StatsigUserBuilder {
+	b := NewUserBuilderWithUserID(userID)
+	b.allowNilUserID = s.allowNilUserID
+	return b
+}
+
+func (s *Statsig) NewUserBuilderWithCustomIDs(customIDs map[string]any) *StatsigUserBuilder {
+	b := NewUserBuilderWithCustomIDs(customIDs)
+	b.allowNilUserID = s.allowNilUserID
+	return b
 }
 
 func (s *Statsig) Initialize() {

--- a/statsig-go/statsig_options.go
+++ b/statsig-go/statsig_options.go
@@ -7,7 +7,8 @@ import (
 )
 
 type StatsigOptions struct {
-	ref uint64
+	ref            uint64
+	allowNilUserID bool
 }
 
 type StatsigOptionsBuilder struct {
@@ -35,6 +36,8 @@ type StatsigOptionsBuilder struct {
 	PersistentStorageRef        *uint64 `json:"persistent_storage_ref,omitempty"`
 	InitTimeoutMs               *int32  `json:"init_timeout_ms,omitempty"`
 	FallbackToStatsigApi        *bool   `json:"fallback_to_statsig_api,omitempty"`
+
+	AllowNilUserID bool `json:"-"`
 }
 
 func NewOptionsBuilder() *StatsigOptionsBuilder {
@@ -141,6 +144,11 @@ func (o *StatsigOptionsBuilder) WithPersistentStorage(persistentStorage *Persist
 	return o
 }
 
+func (o *StatsigOptionsBuilder) WithAllowNilUserID(allow bool) *StatsigOptionsBuilder {
+	o.AllowNilUserID = allow
+	return o
+}
+
 func (o *StatsigOptionsBuilder) Build() (*StatsigOptions, error) {
 	data, err := json.Marshal(o)
 	if err != nil {
@@ -156,7 +164,8 @@ func (o *StatsigOptionsBuilder) Build() (*StatsigOptions, error) {
 	}
 
 	options := &StatsigOptions{
-		ref,
+		ref:            ref,
+		allowNilUserID: o.AllowNilUserID,
 	}
 
 	runtime.SetFinalizer(options, func(obj *StatsigOptions) {

--- a/statsig-go/statsig_user.go
+++ b/statsig-go/statsig_user.go
@@ -12,7 +12,7 @@ type StatsigUser struct {
 
 // todo: introduce custom type for handling valid JSON primitives only instead of using 'any'
 type StatsigUserBuilder struct {
-	UserID string `json:"userID"`
+	UserID *string `json:"userID,omitempty"`
 	// map[string] string | number
 	CustomIDs  map[string]any `json:"customIDs"`
 	Email      *string        `json:"email"`
@@ -29,7 +29,7 @@ type StatsigUserBuilder struct {
 
 func NewUserBuilderWithUserID(userID string) *StatsigUserBuilder {
 	return &StatsigUserBuilder{
-		UserID: userID,
+		UserID: &userID,
 	}
 }
 
@@ -40,7 +40,7 @@ func NewUserBuilderWithCustomIDs(customIDs map[string]any) *StatsigUserBuilder {
 }
 
 func (b *StatsigUserBuilder) WithUserID(userID string) *StatsigUserBuilder {
-	b.UserID = userID
+	b.UserID = &userID
 	return b
 }
 

--- a/statsig-go/statsig_user.go
+++ b/statsig-go/statsig_user.go
@@ -25,6 +25,8 @@ type StatsigUserBuilder struct {
 	Custom *map[string]any `json:"custom"`
 	// map[string] string | number | boolean | array<string>
 	PrivateAttributes *map[string]any `json:"privateAttributes"`
+
+	allowNilUserID bool
 }
 
 func NewUserBuilderWithUserID(userID string) *StatsigUserBuilder {
@@ -90,7 +92,12 @@ func (b *StatsigUserBuilder) WithPrivateAttributes(privateAttributes map[string]
 }
 
 func (b *StatsigUserBuilder) Build() (*StatsigUser, error) {
-	jsonData, err := json.Marshal(b)
+	snapshot := *b
+	if !b.allowNilUserID && snapshot.UserID == nil {
+		empty := ""
+		snapshot.UserID = &empty
+	}
+	jsonData, err := json.Marshal(&snapshot)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling user: %v", err)
 	}

--- a/statsig-go/test/statsig_user_test.go
+++ b/statsig-go/test/statsig_user_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"encoding/json"
 	"testing"
 
 	statsig_go "github.com/statsig-io/statsig-go-core"
@@ -11,5 +12,74 @@ func TestStatsigUserBuilder(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("error creating StatsigUser: %v", err)
+	}
+}
+
+func TestStatsigUserBuilderJSONShape(t *testing.T) {
+	cases := []struct {
+		name           string
+		builder        *statsig_go.StatsigUserBuilder
+		wantUserIDKey  bool
+		wantUserIDVal  string
+	}{
+		{
+			name:          "with_user_id",
+			builder:       statsig_go.NewUserBuilderWithUserID("u1"),
+			wantUserIDKey: true,
+			wantUserIDVal: "u1",
+		},
+		{
+			name:          "with_empty_user_id",
+			builder:       statsig_go.NewUserBuilderWithUserID(""),
+			wantUserIDKey: true,
+			wantUserIDVal: "",
+		},
+		{
+			name:          "custom_ids_only",
+			builder:       statsig_go.NewUserBuilderWithCustomIDs(map[string]any{"stableID": "abc"}),
+			wantUserIDKey: false,
+		},
+		{
+			name:          "override_to_empty",
+			builder:       statsig_go.NewUserBuilderWithUserID("u1").WithUserID(""),
+			wantUserIDKey: true,
+			wantUserIDVal: "",
+		},
+		{
+			name:          "custom_ids_then_user_id",
+			builder:       statsig_go.NewUserBuilderWithCustomIDs(map[string]any{"stableID": "abc"}).WithUserID("u2"),
+			wantUserIDKey: true,
+			wantUserIDVal: "u2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.builder)
+			if err != nil {
+				t.Fatalf("json.Marshal failed: %v", err)
+			}
+
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatalf("json.Unmarshal failed: %v", err)
+			}
+
+			raw, ok := m["userID"]
+			if ok != tc.wantUserIDKey {
+				t.Fatalf("userID key presence = %v, want %v (json=%s)", ok, tc.wantUserIDKey, string(data))
+			}
+			if !ok {
+				return
+			}
+
+			var got string
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("userID value not a JSON string: %v (raw=%s)", err, string(raw))
+			}
+			if got != tc.wantUserIDVal {
+				t.Errorf("userID = %q, want %q", got, tc.wantUserIDVal)
+			}
+		})
 	}
 }

--- a/statsig-go/test/statsig_user_test.go
+++ b/statsig-go/test/statsig_user_test.go
@@ -15,6 +15,126 @@ func TestStatsigUserBuilder(t *testing.T) {
 	}
 }
 
+func TestStatsigUserBuilder_AllowNilUserID(t *testing.T) {
+	cases := []struct {
+		name      string
+		allowNil  bool
+		configure func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder
+	}{
+		{
+			name:      "default_with_user_id",
+			allowNil:  false,
+			configure: func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder { return b.WithUserID("u1") },
+		},
+		{
+			name:      "default_with_empty_user_id",
+			allowNil:  false,
+			configure: func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder { return b.WithUserID("") },
+		},
+		{
+			name:      "default_with_nil_user_id_custom_ids",
+			allowNil:  false,
+			configure: func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder { return b },
+		},
+		{
+			name:      "optin_with_user_id",
+			allowNil:  true,
+			configure: func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder { return b.WithUserID("u1") },
+		},
+		{
+			name:      "optin_with_empty_user_id",
+			allowNil:  true,
+			configure: func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder { return b.WithUserID("") },
+		},
+		{
+			name:      "optin_with_nil_user_id_custom_ids",
+			allowNil:  true,
+			configure: func(b *statsig_go.StatsigUserBuilder) *statsig_go.StatsigUserBuilder { return b },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStatsigForUserBuilder(t, tc.allowNil)
+			b := tc.configure(s.NewUserBuilderWithCustomIDs(map[string]any{"stableID": "x"}))
+
+			user, err := b.Build()
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if user == nil {
+				t.Fatalf("Build() returned nil user with no error")
+			}
+		})
+	}
+}
+
+func TestStatsigUserBuilder_AllowNilUserID_FreeFunctionDefault(t *testing.T) {
+	cases := []struct {
+		name    string
+		builder func() *statsig_go.StatsigUserBuilder
+	}{
+		{
+			name:    "free_fn_with_user_id",
+			builder: func() *statsig_go.StatsigUserBuilder { return statsig_go.NewUserBuilderWithUserID("u1") },
+		},
+		{
+			name:    "free_fn_custom_ids_only_coerces_nil",
+			builder: func() *statsig_go.StatsigUserBuilder { return statsig_go.NewUserBuilderWithCustomIDs(map[string]any{"stableID": "x"}) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, err := tc.builder().Build()
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if user == nil {
+				t.Fatalf("Build() returned nil user with no error")
+			}
+		})
+	}
+}
+
+func TestStatsigUserBuilder_BuildDoesNotMutate(t *testing.T) {
+	s := newStatsigForUserBuilder(t, false)
+	b := s.NewUserBuilderWithCustomIDs(map[string]any{"stableID": "x"})
+
+	if b.UserID != nil {
+		t.Fatalf("precondition: builder.UserID = %v, want nil", b.UserID)
+	}
+
+	if _, err := b.Build(); err != nil {
+		t.Fatalf("first Build() error = %v", err)
+	}
+	if b.UserID != nil {
+		t.Fatalf("after first Build(): builder.UserID = %v, want nil (Build must not mutate)", *b.UserID)
+	}
+
+	if _, err := b.Build(); err != nil {
+		t.Fatalf("second Build() error = %v", err)
+	}
+	if b.UserID != nil {
+		t.Fatalf("after second Build(): builder.UserID = %v, want nil (Build must not mutate)", *b.UserID)
+	}
+}
+
+func newStatsigForUserBuilder(t *testing.T, allowNilUserID bool) *statsig_go.Statsig {
+	t.Helper()
+	opts, err := statsig_go.NewOptionsBuilder().
+		WithAllowNilUserID(allowNilUserID).
+		Build()
+	if err != nil {
+		t.Fatalf("options Build() error = %v", err)
+	}
+	s, err := statsig_go.NewStatsigWithOptions("secret-test", opts)
+	if err != nil {
+		t.Fatalf("NewStatsigWithOptions error = %v", err)
+	}
+	return s
+}
+
 func TestStatsigUserBuilderJSONShape(t *testing.T) {
 	cases := []struct {
 		name           string


### PR DESCRIPTION
## Context

The Go `StatsigUserBuilder` always serialized `userID` to JSON, even when the caller never set it. A customIDs-only builder produced `{"userID":""}` on the wire, and the Rust core deserialized that into `Some(DynamicValue(""))` instead of `None`. The first commit on this branch added `json:"userID,omitempty"`, which omitted the key entirely when `UserID` was nil. That's a behavioral change at the FFI boundary. `null`, `""`, and missing-key all hash differently in `create_exposure_dedupe_user_hash` (`statsig-rust/src/user/user_data.rs:40-55`), so flipping the wire shape silently shifts exposure-dedup keys for any caller that doesn't set `UserID`.

## Approach

Gate the omission behind an SDK-level opt-in. Default behavior is backward-safe: when `AllowNilUserID = false`, `Build()` coerces a nil `UserID` to `&""` on a local snapshot before marshalling, so the wire JSON carries `"userID": ""`. When `AllowNilUserID = true`, the snapshot is left alone and the existing `omitempty` tag drops the key entirely.

The flag lives on `StatsigOptions` (Go-side only, `json:"-"` so it isn't forwarded to Rust). Rust has no concept of it. Two paths set it on a builder: `(*Statsig).NewUserBuilderWith{UserID,CustomIDs}` picks up the SDK-level value, and the free-function `NewUserBuilderWith{UserID,CustomIDs}` always defaults to `false` so existing call sites compile and keep their current behavior.

`Build()` works on a shallow copy of the builder, so a caller invoking `Build()` twice on the same builder gets identical results. No in-place mutation of `UserID`.

Note: the default-off path coerces nil to `""`, not nil to `null`. Both are non-nil at the Rust boundary, so evaluation results don't shift. Exposure-dedup hashes will shift one-time from `ahash_str("null")` to `ahash_str("")` for users that previously rode the pre-fix `null` path with no `UserID` set. Confirmed acceptable in design.

Design: `designs-go-omit-nil-userid-opt-in.md`

## Reviewer guide

- The load-bearing invariant: `Build()` must not mutate the caller's `*StatsigUserBuilder`. `snapshot := *b` does a shallow copy; only the `UserID` pointer field is swapped on the snapshot. `TestStatsigUserBuilder_BuildDoesNotMutate` covers this directly.
- `AllowNilUserID` carries `json:"-"`. It must never appear in the JSON forwarded to Rust.
- Free functions keep their existing signatures, so any existing caller of `NewUserBuilderWithUserID` or `NewUserBuilderWithCustomIDs` compiles and behaves the same as before this PR (modulo `null` to `""` for the nil-UserID + customIDs case, called out above).
- The first commit on this branch (`omitempty` tag) is functionally inert when the opt-in is off. The coercion in `Build()` always produces a non-nil pointer before marshalling, so `omitempty` never triggers in the default path.

## Changes

- `statsig-go/statsig_options.go`: added `AllowNilUserID bool` (`json:"-"`) on `StatsigOptionsBuilder`, new `WithAllowNilUserID(bool)` builder method, and propagated to the new private `StatsigOptions.allowNilUserID` field.
- `statsig-go/statsig.go`: added private `Statsig.allowNilUserID` populated from options at construction; new `(*Statsig).NewUserBuilderWithUserID` and `(*Statsig).NewUserBuilderWithCustomIDs` propagate the flag to the builder.
- `statsig-go/statsig_user.go`: `UserID *string` with `json:"userID,omitempty"` (first commit) plus private `allowNilUserID` field (second commit); `Build()` takes a shallow snapshot and coerces nil → `&""` when the flag is off.
- `statsig-go/test/statsig_user_test.go`: added `TestStatsigUserBuilderJSONShape` (wire-shape table-driven, 5 subtests), `TestStatsigUserBuilder_AllowNilUserID` (flag × UserID state matrix, 6 subtests through `*Statsig` instance methods), `TestStatsigUserBuilder_AllowNilUserID_FreeFunctionDefault` (free-function default behavior, 2 subtests), and `TestStatsigUserBuilder_BuildDoesNotMutate` (no-mutation invariant).

## Testing

- `cd statsig-go && go build ./...` — passes.
- `go test -run "TestStatsigUserBuilderJSONShape|TestStatsigUserBuilder_AllowNilUserID|TestStatsigUserBuilder_BuildDoesNotMutate" ./...` — all subtests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
