### PR TITLE
S2SDK-1: (memory leak Fix) bound exposure dedupe set with LRU to prev…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +952,17 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1444,6 +1467,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "maplit"
@@ -3011,6 +3043,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "lru",
  "memmap2",
  "mockito",
  "more-asserts",

--- a/statsig-ffi/src/statsig_options_c.rs
+++ b/statsig-ffi/src/statsig_options_c.rs
@@ -39,6 +39,7 @@ pub struct StatsigOptionsData {
     event_logging_adapter_ref: Option<u64>,
     event_logging_max_pending_batch_queue_size: Option<u32>,
     event_logging_max_queue_size: Option<u32>,
+    exposure_dedupe_max_keys: Option<usize>,
     fallback_to_statsig_api: Option<bool>,
     global_custom_fields: Option<HashMap<String, DynamicValue>>,
     download_id_list_file_api: Option<String>,
@@ -153,6 +154,7 @@ impl From<StatsigOptionsData> for StatsigOptions {
             event_logging_flush_interval_ms: None, // Deprecated
             event_logging_max_pending_batch_queue_size,
             event_logging_max_queue_size: data.event_logging_max_queue_size,
+            exposure_dedupe_max_keys: data.exposure_dedupe_max_keys,
             fallback_to_statsig_api: data.fallback_to_statsig_api,
             global_custom_fields: data.global_custom_fields,
             id_lists_adapter: None, // todo: add support for id lists adapter

--- a/statsig-go/statsig_options.go
+++ b/statsig-go/statsig_options.go
@@ -17,6 +17,7 @@ type StatsigOptionsBuilder struct {
 	ServiceName                 *string `json:"service_name,omitempty"`
 	EventLoggingFlushIntervalMs *int32  `json:"event_logging_flush_interval_ms,omitempty"`
 	EventLoggingMaxQueueSize    *int32  `json:"event_logging_max_queue_size,omitempty"`
+	ExposureDedupeMaxKeys       *int32  `json:"exposure_dedupe_max_keys,omitempty"`
 	SpecsSyncIntervalMs         *int32  `json:"specs_sync_interval_ms,omitempty"`
 	OutputLogLevel              *string `json:"output_log_level,omitempty"`
 	DisableCountryLookup        *bool   `json:"disable_country_lookup,omitempty"`
@@ -68,6 +69,11 @@ func (o *StatsigOptionsBuilder) WithEventLoggingFlushIntervalMs(eventLoggingFlus
 
 func (o *StatsigOptionsBuilder) WithEventLoggingMaxQueueSize(eventLoggingMaxQueueSize int32) *StatsigOptionsBuilder {
 	o.EventLoggingMaxQueueSize = &eventLoggingMaxQueueSize
+	return o
+}
+
+func (o *StatsigOptionsBuilder) WithExposureDedupeMaxKeys(exposureDedupeMaxKeys int32) *StatsigOptionsBuilder {
+	o.ExposureDedupeMaxKeys = &exposureDedupeMaxKeys
 	return o
 }
 

--- a/statsig-node/src/statsig_options_napi.rs
+++ b/statsig-node/src/statsig_options_napi.rs
@@ -245,6 +245,7 @@ impl StatsigOptions<'_> {
             #[allow(deprecated)]
             event_logging_flush_interval_ms: None,
             event_logging_max_pending_batch_queue_size: None,
+            exposure_dedupe_max_keys: None,
             id_lists_adapter: None,
             specs_adapter: None,
             disable_disk_access: None,

--- a/statsig-pyo3/src/statsig_options_py.rs
+++ b/statsig-pyo3/src/statsig_options_py.rs
@@ -357,6 +357,7 @@ fn create_inner_statsig_options(
         event_logging_flush_interval_ms: None,
         event_logging_max_queue_size: opts.event_logging_max_queue_size,
         event_logging_max_pending_batch_queue_size: opts.event_logging_max_pending_batch_queue_size,
+        exposure_dedupe_max_keys: None,
         enable_id_lists: opts.enable_id_lists,
         enable_dcs_deltas: opts.enable_dcs_deltas,
         id_lists_url: opts.id_lists_url.clone(),

--- a/statsig-rust/Cargo.toml
+++ b/statsig-rust/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.30"
 indexmap = { version = "2.13.0", features = ["serde"], optional = true }
 lazy_static = "1.5.0"
 log = "0.4.22"
+lru = "0.12"
 parking_lot = "0.12.1"
 percent-encoding = "2.3.1"
 rand = "0.8.4"

--- a/statsig-rust/src/event_logging/event_logger.rs
+++ b/statsig-rust/src/event_logging/event_logger.rs
@@ -79,7 +79,10 @@ impl EventLogger {
                     .event_logging_max_pending_batch_queue_size
                     .unwrap_or(DEFAULT_PENDING_BATCH_COUNT_MAX),
             ),
-            event_sampler: ExposureSampling::new(sdk_key),
+            event_sampler: ExposureSampling::with_max_keys(
+                sdk_key,
+                options.exposure_dedupe_max_keys,
+            ),
             flush_interval: FlushInterval::new(),
             options: options.clone(),
             logging_adapter: event_logging_adapter.clone(),

--- a/statsig-rust/src/event_logging/exposure_sampling.rs
+++ b/statsig-rust/src/event_logging/exposure_sampling.rs
@@ -63,11 +63,9 @@ impl ExposureSampling {
     pub fn with_max_keys(sdk_key: &str, max_keys: Option<usize>) -> Self {
         let now = Utc::now().timestamp_millis() as u64;
 
-        let cap = max_keys
-            .and_then(NonZeroUsize::new)
-            .unwrap_or_else(|| {
-                NonZeroUsize::new(SAMPLING_MAX_KEYS).expect("SAMPLING_MAX_KEYS must be non-zero")
-            });
+        let cap = max_keys.and_then(NonZeroUsize::new).unwrap_or_else(|| {
+            NonZeroUsize::new(SAMPLING_MAX_KEYS).expect("SAMPLING_MAX_KEYS must be non-zero")
+        });
 
         Self {
             spec_sampling_set: RwLock::from(AHashSet::default()),

--- a/statsig-rust/src/event_logging/exposure_sampling.rs
+++ b/statsig-rust/src/event_logging/exposure_sampling.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 use ahash::AHashSet;
 use chrono::Utc;
+use lru::LruCache;
 use parking_lot::RwLock;
+use std::num::NonZeroUsize;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -16,7 +18,7 @@ use std::sync::{
 
 const TAG: &str = "ExposureSampling";
 const DEFAULT_EXPOSURE_SAMPLING_TTL_MS: u64 = 60_000;
-const SAMPLING_MAX_KEYS: usize = 100_000;
+pub const SAMPLING_MAX_KEYS: usize = 100_000;
 
 #[derive(Debug)]
 pub enum EvtSamplingMode {
@@ -46,7 +48,8 @@ pub struct ExposureSampling {
     spec_sampling_set: RwLock<AHashSet<SpecAndRuleHashTuple>>,
     last_spec_sampling_reset: AtomicU64,
 
-    exposure_dedupe_set: RwLock<AHashSet<ExposureSamplingKey>>,
+    exposure_dedupe_set: RwLock<LruCache<ExposureSamplingKey, ()>>,
+    exposure_dedupe_max_keys: NonZeroUsize,
     last_exposure_dedupe_reset: AtomicU64,
 
     global_configs: Arc<GlobalConfigs>,
@@ -54,13 +57,24 @@ pub struct ExposureSampling {
 
 impl ExposureSampling {
     pub fn new(sdk_key: &str) -> Self {
+        Self::with_max_keys(sdk_key, None)
+    }
+
+    pub fn with_max_keys(sdk_key: &str, max_keys: Option<usize>) -> Self {
         let now = Utc::now().timestamp_millis() as u64;
+
+        let cap = max_keys
+            .and_then(NonZeroUsize::new)
+            .unwrap_or_else(|| {
+                NonZeroUsize::new(SAMPLING_MAX_KEYS).expect("SAMPLING_MAX_KEYS must be non-zero")
+            });
 
         Self {
             spec_sampling_set: RwLock::from(AHashSet::default()),
             last_spec_sampling_reset: AtomicU64::from(now),
 
-            exposure_dedupe_set: RwLock::from(AHashSet::default()),
+            exposure_dedupe_set: RwLock::from(LruCache::new(cap)),
+            exposure_dedupe_max_keys: cap,
             last_exposure_dedupe_reset: AtomicU64::from(now),
 
             global_configs: GlobalConfigs::get_instance(sdk_key),
@@ -121,11 +135,11 @@ impl ExposureSampling {
 
     fn should_dedupe_exposure(&self, sampling_key: &ExposureSamplingKey) -> bool {
         let mut dedupe_set = write_lock_or_return!(TAG, self.exposure_dedupe_set, false);
-        if dedupe_set.contains(sampling_key) {
+        if dedupe_set.get(sampling_key).is_some() {
             return true;
         }
 
-        dedupe_set.insert(sampling_key.clone());
+        dedupe_set.put(sampling_key.clone(), ());
         false
     }
 
@@ -210,16 +224,10 @@ impl ExposureSampling {
         };
 
         let has_expired = now - last_dedupe_reset > ttl_ms;
-        let is_full = dedupe_map.len() > SAMPLING_MAX_KEYS;
 
-        if has_expired || is_full {
-            log_d!(
-                TAG,
-                "Resetting exposure dedupe set. has_expired: {:?}, is_full: {:?}",
-                has_expired,
-                is_full
-            );
-            dedupe_map.clear();
+        if has_expired {
+            log_d!(TAG, "Resetting exposure dedupe set (ttl expired)");
+            *dedupe_map = LruCache::new(self.exposure_dedupe_max_keys);
             self.last_exposure_dedupe_reset
                 .store(now, Ordering::Relaxed);
         }

--- a/statsig-rust/src/statsig_options.rs
+++ b/statsig-rust/src/statsig_options.rs
@@ -44,6 +44,11 @@ pub struct StatsigOptions {
     pub event_logging_max_pending_batch_queue_size: Option<u32>,
     pub event_logging_max_queue_size: Option<u32>,
 
+    /// Hard upper bound on unique `ExposureSamplingKey`s in the exposure-dedupe LRU
+    /// cache. Defaults to [`crate::event_logging::exposure_sampling::SAMPLING_MAX_KEYS`]
+    /// (100_000). `Some(0)` is treated as "use the default".
+    pub exposure_dedupe_max_keys: Option<usize>,
+
     pub fallback_to_statsig_api: Option<bool>,
     pub global_custom_fields: Option<HashMap<String, DynamicValue>>,
 
@@ -184,6 +189,12 @@ impl StatsigOptionsBuilder {
     ) -> Self {
         self.inner.event_logging_max_pending_batch_queue_size =
             event_logging_max_pending_batch_queue_size;
+        self
+    }
+
+    #[must_use]
+    pub fn exposure_dedupe_max_keys(mut self, exposure_dedupe_max_keys: Option<usize>) -> Self {
+        self.inner.exposure_dedupe_max_keys = exposure_dedupe_max_keys;
         self
     }
 

--- a/statsig-rust/tests/memory_leak_per_request_users_tests.rs
+++ b/statsig-rust/tests/memory_leak_per_request_users_tests.rs
@@ -1,0 +1,104 @@
+//! Regression test for unbounded growth in `ExposureSampling::should_dedupe_exposure`.
+//!
+//! Each iteration uses a distinct `user_id`, which previously inserted into an
+//! unbounded `HashSet` and grew RSS with unique-user cardinality.
+//!
+//! With the bounded LRU fix, RSS growth should stay under the threshold below over
+//! 10k iterations on a minimal user. The test sets a small `exposure_dedupe_max_keys`
+//! (1_000) to force insert-time eviction.
+//!
+//! Run manually on Linux:
+//! `cargo test --release --test memory_leak_per_request_users_tests -- --ignored`
+
+mod utils;
+
+use crate::utils::mock_event_logging_adapter::MockEventLoggingAdapter;
+use crate::utils::mock_specs_adapter::MockSpecsAdapter;
+use statsig_rust::{
+    ClientInitResponseOptions, Statsig, StatsigOptions, StatsigUser,
+};
+use std::sync::Arc;
+
+const ITERATIONS: usize = 10_000;
+const DEDUPE_CAP: usize = 1_000;
+const MAX_RSS_GROWTH_BYTES: i64 = 50 * 1024 * 1024;
+
+const GATE_NAME: &str = "test_public";
+const CONFIG_NAME: &str = "test_empty_array";
+const EXPERIMENT_NAME: &str = "test_experiment_no_targeting";
+const LAYER_NAME: &str = "test_layer";
+
+#[cfg(target_os = "linux")]
+fn read_rss_bytes() -> Option<i64> {
+    let contents = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let kb: i64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_rss_bytes() -> Option<i64> {
+    None
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_memory_leak_per_request_users_bounded() {
+    let specs_adapter = Arc::new(MockSpecsAdapter::with_data(
+        "tests/data/eval_proj_dcs.json",
+    ));
+    let logging_adapter = Arc::new(MockEventLoggingAdapter::new());
+
+    let statsig = Statsig::new(
+        "secret-shhh",
+        Some(Arc::new(StatsigOptions {
+            specs_adapter: Some(specs_adapter.clone()),
+            event_logging_adapter: Some(logging_adapter.clone()),
+            exposure_dedupe_max_keys: Some(DEDUPE_CAP),
+            ..StatsigOptions::new()
+        })),
+    );
+    statsig.initialize().await.unwrap();
+
+    {
+        let warmup_user = StatsigUser::with_user_id("warmup");
+        let _ = statsig.check_gate(&warmup_user, GATE_NAME);
+    }
+
+    let initial_rss =
+        read_rss_bytes().expect("RSS reading is only supported on Linux");
+
+    for i in 0..ITERATIONS {
+        let user = StatsigUser::with_user_id(format!("user-{i}"));
+
+        let _ = statsig.check_gate(&user, GATE_NAME);
+        let _ = statsig.get_dynamic_config(&user, CONFIG_NAME);
+        let _ = statsig.get_experiment(&user, EXPERIMENT_NAME);
+        let _ = statsig.get_layer(&user, LAYER_NAME);
+        let _ = statsig.get_client_init_response_with_options(
+            &user,
+            &ClientInitResponseOptions::default(),
+        );
+    }
+
+    let final_rss = read_rss_bytes().expect("RSS read after loop");
+    let delta = final_rss - initial_rss;
+
+    println!(
+        "RSS: initial = {:.2} MB, final = {:.2} MB, delta = {:+.2} MB",
+        initial_rss as f64 / 1024.0 / 1024.0,
+        final_rss as f64 / 1024.0 / 1024.0,
+        delta as f64 / 1024.0 / 1024.0,
+    );
+
+    let _ = statsig.shutdown().await;
+
+    assert!(
+        delta < MAX_RSS_GROWTH_BYTES,
+        "RSS grew by {delta} bytes (> {MAX_RSS_GROWTH_BYTES} bytes); exposure dedupe cache may be unbounded again"
+    );
+}

--- a/statsig-rust/tests/memory_leak_per_request_users_tests.rs
+++ b/statsig-rust/tests/memory_leak_per_request_users_tests.rs
@@ -20,6 +20,7 @@ use statsig_rust::{
 use std::sync::Arc;
 
 const ITERATIONS: usize = 10_000;
+const WARMUP_ITERATIONS: usize = 1_000;
 const DEDUPE_CAP: usize = 1_000;
 const MAX_RSS_GROWTH_BYTES: i64 = 50 * 1024 * 1024;
 
@@ -64,28 +65,39 @@ async fn test_memory_leak_per_request_users_bounded() {
     );
     statsig.initialize().await.unwrap();
 
-    {
-        let warmup_user = StatsigUser::with_user_id("warmup");
-        let _ = statsig.check_gate(&warmup_user, GATE_NAME);
+    // Warm-up: run the full operation set so lazy initialization, evaluation
+    // caches, and allocator bucket growth settle before we capture the baseline.
+    // Otherwise first-iteration allocations would be counted as "growth".
+    for i in 0..WARMUP_ITERATIONS {
+        let user = StatsigUser::with_user_id(format!("warmup-{i}"));
+        run_evaluations(&statsig, &user);
     }
 
-    let initial_rss =
-        read_rss_bytes().expect("RSS reading is only supported on Linux");
+    // RSS is only readable on Linux (/proc/self/status). On other platforms we
+    // can't measure, so skip gracefully rather than panicking the CI job.
+    let initial_rss = match read_rss_bytes() {
+        Some(rss) => rss,
+        None => {
+            println!("Skipping RSS assertion: not supported on this platform");
+            let _ = statsig.shutdown().await;
+            return;
+        }
+    };
 
     for i in 0..ITERATIONS {
         let user = StatsigUser::with_user_id(format!("user-{i}"));
-
-        let _ = statsig.check_gate(&user, GATE_NAME);
-        let _ = statsig.get_dynamic_config(&user, CONFIG_NAME);
-        let _ = statsig.get_experiment(&user, EXPERIMENT_NAME);
-        let _ = statsig.get_layer(&user, LAYER_NAME);
-        let _ = statsig.get_client_init_response_with_options(
-            &user,
-            &ClientInitResponseOptions::default(),
-        );
+        run_evaluations(&statsig, &user);
     }
 
-    let final_rss = read_rss_bytes().expect("RSS read after loop");
+    let final_rss = match read_rss_bytes() {
+        Some(rss) => rss,
+        None => {
+            println!("Skipping RSS assertion: could not read RSS after loop");
+            let _ = statsig.shutdown().await;
+            return;
+        }
+    };
+
     let delta = final_rss - initial_rss;
 
     println!(
@@ -100,5 +112,16 @@ async fn test_memory_leak_per_request_users_bounded() {
     assert!(
         delta < MAX_RSS_GROWTH_BYTES,
         "RSS grew by {delta} bytes (> {MAX_RSS_GROWTH_BYTES} bytes); exposure dedupe cache may be unbounded again"
+    );
+}
+
+fn run_evaluations(statsig: &Statsig, user: &StatsigUser) {
+    let _ = statsig.check_gate(user, GATE_NAME);
+    let _ = statsig.get_dynamic_config(user, CONFIG_NAME);
+    let _ = statsig.get_experiment(user, EXPERIMENT_NAME);
+    let _ = statsig.get_layer(user, LAYER_NAME);
+    let _ = statsig.get_client_init_response_with_options(
+        user,
+        &ClientInitResponseOptions::default(),
     );
 }

--- a/statsig-rust/tests/memory_leak_per_request_users_tests.rs
+++ b/statsig-rust/tests/memory_leak_per_request_users_tests.rs
@@ -14,9 +14,7 @@ mod utils;
 
 use crate::utils::mock_event_logging_adapter::MockEventLoggingAdapter;
 use crate::utils::mock_specs_adapter::MockSpecsAdapter;
-use statsig_rust::{
-    ClientInitResponseOptions, Statsig, StatsigOptions, StatsigUser,
-};
+use statsig_rust::{ClientInitResponseOptions, Statsig, StatsigOptions, StatsigUser};
 use std::sync::Arc;
 
 const ITERATIONS: usize = 10_000;
@@ -49,9 +47,7 @@ fn read_rss_bytes() -> Option<i64> {
 #[tokio::test]
 #[ignore]
 async fn test_memory_leak_per_request_users_bounded() {
-    let specs_adapter = Arc::new(MockSpecsAdapter::with_data(
-        "tests/data/eval_proj_dcs.json",
-    ));
+    let specs_adapter = Arc::new(MockSpecsAdapter::with_data("tests/data/eval_proj_dcs.json"));
     let logging_adapter = Arc::new(MockEventLoggingAdapter::new());
 
     let statsig = Statsig::new(
@@ -120,8 +116,6 @@ fn run_evaluations(statsig: &Statsig, user: &StatsigUser) {
     let _ = statsig.get_dynamic_config(user, CONFIG_NAME);
     let _ = statsig.get_experiment(user, EXPERIMENT_NAME);
     let _ = statsig.get_layer(user, LAYER_NAME);
-    let _ = statsig.get_client_init_response_with_options(
-        user,
-        &ClientInitResponseOptions::default(),
-    );
+    let _ =
+        statsig.get_client_init_response_with_options(user, &ClientInitResponseOptions::default());
 }


### PR DESCRIPTION
…ent unbounded memory growth

fix: bound exposure dedupe set with LRU to prevent unbounded memory growth

Replaces the unbounded AHashSet<ExposureSamplingKey> in
ExposureSampling::should_dedupe_exposure with a bounded lru::LruCache.
Every unique user_id previously added a permanent entry, causing steady
RSS growth on high-cardinality server workloads (~50 MiB/h/pod reported
at DeepL in statsig-io/statsig-server-core#47).

- Eviction now happens on insert via put(); get() bumps recency
- TTL reset reallocates the cache instead of clear() so peak bucket
  allocation is released
- Add configurable StatsigOptions::exposure_dedupe_max_keys (default
  100_000), plumbed through the C FFI and Go bindings
- Add ignored RSS regression test (Linux only)